### PR TITLE
feat: :sparkles: Select optimal projections with a slider (#6)

### DIFF
--- a/webct/blueprints/capture/static/scss/capture.scss
+++ b/webct/blueprints/capture/static/scss/capture.scss
@@ -64,3 +64,21 @@ video[src=""] {
 .overlay .generating {
 	display: none;
 }
+
+div.group > sl-dropdown > sl-menu {
+	width: 100%;
+}
+
+sl-menu > sl-range {
+	padding: 0.5rem;
+	overflow-x: hidden;
+
+}
+
+sl-range.linked {
+	--track-color-active: var(--sl-color-primary-500);
+}
+
+sl-range::part(tooltip) {
+	z-index: var(--sl-z-index-tooltip);
+}

--- a/webct/blueprints/capture/templates/tab.capture.html.j2
+++ b/webct/blueprints/capture/templates/tab.capture.html.j2
@@ -17,7 +17,13 @@
 
 		<sl-input label="Total projections" type="number" id="inputCaptureProjections" min="2" max="2000" step="1"
 			value="360"></sl-input>
-		<!-- <sl-button type="primary">Calculate Optimal Projections</sl-button> -->
+		<sl-dropdown>
+			<sl-button slot="trigger" caret>Optimal Projections</sl-button>
+			<sl-menu>
+				<sl-range id="rangeNyquist" label="Nyquist" max="100" min="1" step="1"
+					help-text="π/2 * Horizontal Detector Pixels"></sl-range>
+			</sl-menu>
+		</sl-dropdown>
 	</div>
 	<!-- <button></button> -->
 </div>

--- a/webct/blueprints/detector/static/js/detector.ts
+++ b/webct/blueprints/detector/static/js/detector.ts
@@ -13,9 +13,9 @@ import { validateHeight, validatePixel, validateWidth } from "./validation";
 // ====================================================== //
 // ================== Document Elements ================= //
 // ====================================================== //
-let PaneWidthElement: SlInput;
+export let PaneWidthElement: SlInput;
 let PaneHeightElement: SlInput;
-let PanePixelSizeElement: SlInput;
+export let PanePixelSizeElement: SlInput;
 let DetectorPreviewElement: HTMLDivElement;
 let DetectorHorizontalText: SVGTextElement;
 let DetectorVerticalText: SVGTextElement;


### PR DESCRIPTION
Using a slider, auto-fill projection count as a percentage of Nyquist value.

![image](https://user-images.githubusercontent.com/35181365/174488170-ea457ede-6bd7-484e-a782-844517088624.png)

If projections was changed by the slider, it has a blue bar. If projections was changed by any other means, the bar goes back to default:
![image](https://user-images.githubusercontent.com/35181365/174488222-c5cdaeac-f9b8-4016-b454-3d0fd9c2bc01.png)

Closes #6
