### PR TITLE
feat: :lipstick: Change MS-App titlebar to a darker blue

### DIFF
--- a/webct/blueprints/app/static/img/favicons/browserconfig.xml
+++ b/webct/blueprints/app/static/img/favicons/browserconfig.xml
@@ -5,7 +5,7 @@
             <square70x70logo src="/mstile-70x70.png"/>
             <square150x150logo src="/mstile-150x150.png"/>
             <square310x310logo src="/mstile-310x310.png"/>
-            <TileColor>#0ea5e9</TileColor>
+            <TileColor>#0284c7</TileColor>
         </tile>
     </msapplication>
 </browserconfig>

--- a/webct/blueprints/app/templates/favicons.html.j2
+++ b/webct/blueprints/app/templates/favicons.html.j2
@@ -5,5 +5,5 @@
 <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#0ea5e9">
 <meta name="apple-mobile-web-app-title" content="WebCT">
 <meta name="application-name" content="WebCT">
-<meta name="msapplication-TileColor" content="#0ea5e9">
-<meta name="theme-color" content="#0ea5e9">
+<meta name="msapplication-TileColor" content="#0284c7">
+<meta name="theme-color" content="#0284c7">


### PR DESCRIPTION
Slight style change to make the titlebar contrast better, compared to the brighter 500 blue.

|Before|After|
|--|--|
| ![image](https://user-images.githubusercontent.com/35181365/174488698-5ac50f9a-779a-4ed8-8ff8-f4654f688af9.png) | ![image](https://user-images.githubusercontent.com/35181365/174488658-f117b502-90a2-4d29-82fe-64d94ffecd5a.png) |