### PR TITLE
fix: :bug: Fix reconstruction overlay and preview sizing (#7)

### DIFF
--- a/webct/blueprints/preview/static/scss/previews.scss
+++ b/webct/blueprints/preview/static/scss/previews.scss
@@ -77,7 +77,7 @@ img.image-layout {
 	display: none;
 }
 
-#previewPane:not([selected=recon]) #previewRecon {
+#previewPane:not([selected=recon]) #previewReconstruction {
 	display: none;
 }
 

--- a/webct/blueprints/preview/templates/preview.pane.html.j2
+++ b/webct/blueprints/preview/templates/preview.pane.html.j2
@@ -29,23 +29,24 @@
 		<img src="" class="image-layout" alt="">
 	</div>
 
-	<div id="previewRecon">
-		<video src="" class="image-recon" alt="" muted autoplay loop></video>
-		<div class="overlay overlay-recon update">
-			<div>
+	<div id="previewReconstruction">
+		<div class="stacker">
+			<video src="" class="image-recon" alt="" muted autoplay loop></video>
+			<div class="overlay overlay-recon update">
 				<div>
-					Use<br />
-					<span>
-						<sl-icon name="box"></sl-icon> Reconstruct
-					</span><br />
-					To perform a tomographic reconstruction on simulated projections.<br>
-				</div>
-				<div class="generating">
-					Reconstructing Volume...<br>
-					<sl-spinner></sl-spinner>
+					<div>
+						Use<br />
+						<span>
+							<sl-icon name="box"></sl-icon> Reconstruct
+						</span><br />
+						To perform a tomographic reconstruction on simulated projections.<br>
+					</div>
+					<div class="generating">
+						Reconstructing Volume...<br>
+						<sl-spinner></sl-spinner>
+					</div>
 				</div>
 			</div>
 		</div>
 	</div>
-
 </div>

--- a/webct/blueprints/reconstruction/static/js/recon.ts
+++ b/webct/blueprints/reconstruction/static/js/recon.ts
@@ -65,8 +65,8 @@ export function setupRecon(): boolean {
 	SliceOverlays = Array.prototype.slice.call(document.querySelectorAll(".overlay-slice") as NodeListOf<HTMLDivElement>);
 
 	Overlays = SinogramOverlays
-	.concat(ReconOverlays)
-	.concat(SliceOverlays);
+		.concat(ReconOverlays)
+		.concat(SliceOverlays);
 
 	const select_alg = document.getElementById("selectReconstruction");
 	const group_alg = document.getElementById("groupAlg")
@@ -172,7 +172,6 @@ export function setupRecon(): boolean {
 	})
 
 	validateRecon();
-	SetOverlaySize(300, 300)
 	return true;
 }
 
@@ -183,29 +182,6 @@ export function validateRecon(): boolean {
 // ====================================================== //
 // =================== Display and UI =================== //
 // ====================================================== //
-
-type OverlayType = "all" | "slice" | "sinogram" | "recon"
-
-function SetOverlaySize(width: number, height: number, type:OverlayType="all"): void {
-	let overlays = Overlays
-	switch (type) {
-		case "recon":
-			overlays = ReconOverlays;
-			break;
-		case "sinogram":
-			overlays = SinogramOverlays;
-		case "slice":
-			overlays = SliceOverlays;
-		default:
-			break;
-	}
-
-	for (let index = 0; index < overlays.length; index++) {
-		const overlay = overlays[index];
-		overlay.style.height = height + "px"
-		overlay.style.width = width + "px"
-	}
-}
 
 function MarkLoading(): void {
 	console.log("markloading");
@@ -319,23 +295,17 @@ function MarkError(): void {
 	}
 }
 
-function SetPreviewImages(preview:ReconstructionPreview): void {
+function SetPreviewImages(preview: ReconstructionPreview): void {
 	for (let index = 0; index < SliceImages.length; index++) {
 		const image = SliceImages[index];
-		image.width = preview.slice.width;
-		image.height = preview.slice.height;
 		image.src = "data:video/mpeg;base64," + preview.slice.video;
 	}
 	for (let index = 0; index < SinogramImages.length; index++) {
 		const image = SinogramImages[index];
-		image.width = preview.sino.width;
-		image.height = preview.sino.height;
 		image.src = "data:video/mpeg;base64," + preview.sino.video;
 	}
 	for (let index = 0; index < ReconImages.length; index++) {
 		const image = ReconImages[index];
-		image.width = preview.recon.width;
-		image.height = preview.recon.height;
 		image.src = "data:video/mpeg;base64," + preview.recon.video;
 	}
 }
@@ -470,10 +440,6 @@ export function UpdateReconPreview(): Promise<void> {
 					cancelable: false,
 					composed: false,
 				}));
-
-				SetOverlaySize(preview.slice.width, preview.slice.height, "slice")
-				SetOverlaySize(preview.sino.width, preview.sino.height, "sinogram")
-				SetOverlaySize(preview.recon.width, preview.recon.height, "recon")
 
 				SetPreviewImages(preview)
 				MarkDone();

--- a/webct/blueprints/reconstruction/static/scss/recon.scss
+++ b/webct/blueprints/reconstruction/static/scss/recon.scss
@@ -3,22 +3,34 @@
 	grid-auto-rows: auto;
 	grid-template-columns: repeat(3, minmax(0, 1fr));
 	column-gap: 2rem;
-	grid-template-areas: "image-slice image-sinogram	 image-recon";
+	grid-template-areas: "recon-slice recon-sinogram recon-recon";
 }
 
-#previewRecon > .image-slice {
-	grid-area: image-slice-start;
-	width: 100%;
-
-}
-
-#previewRecon > .image-sinogram {
-	grid-area: image-sinogram-start;
+#previewRecon .recon-slice {
+	grid-area: recon-slice-start;
 	width: 100%;
 }
 
-#previewRecon > .image-recon {
-	grid-area: image-recon-start;
+#previewRecon > .recon-sinogram {
+	grid-area: recon-sinogram-start;
+	width: 100%;
+}
+
+#previewRecon > .recon-recon {
+	grid-area: recon-recon-start;
+	width: 100%;
+}
+
+div.stacker {
+	// 1x1 grid with a named area
+	grid-template-areas: "t1";
+	grid-template-rows: auto;
+	display: grid;
+}
+
+div.stacker > * {
+	// Stack all children onto the same area
+	grid-area: t1-start;
 	width: 100%;
 }
 

--- a/webct/blueprints/reconstruction/templates/pane.reconstruction.html.j2
+++ b/webct/blueprints/reconstruction/templates/pane.reconstruction.html.j2
@@ -1,50 +1,58 @@
 <div class="previewContainer">
 	<div id="previewRecon">
-		<video src="" class="image-slice" alt="" muted autoplay loop></video>
-		<video src="" class="image-sinogram" alt="" muted autoplay loop></video>
-		<video src="" class="image-recon" alt="" muted autoplay loop></video>
-		<div class="overlay overlay-slice update">
-			<div>
+		<div class="recon-slice stacker">
+			<video src="" class="image-slice" alt="" muted autoplay loop></video>
+			<div class="overlay overlay-slice update">
 				<div>
-					Use<br />
-					<span>
-						<sl-icon name="box"></sl-icon> Reconstruct
-					</span><br />
-					To perform a tomographic reconstruction on simulated projections.<br>
-				</div>
-				<div class="generating">
-					Reconstructing Volume...<br>
-					<sl-spinner></sl-spinner>
+					<div>
+						Use<br />
+						<span>
+							<sl-icon name="box"></sl-icon> Reconstruct
+						</span><br />
+						To perform a tomographic reconstruction on simulated projections.<br>
+					</div>
+					<div class="generating">
+						Reconstructing Volume...<br>
+						<sl-spinner></sl-spinner>
+					</div>
 				</div>
 			</div>
 		</div>
-		<div class="overlay overlay-sinogram update">
-			<div>
+
+		<div class="recon-sinogram stacker">
+			<div class="overlay overlay-sinogram update">
 				<div>
-					Use<br />
-					<span>
-						<sl-icon name="box"></sl-icon> Reconstruct
-					</span><br />
-					To perform a tomographic reconstruction on simulated projections.<br>
-				</div>
-				<div class="generating">
-					Reconstructing Volume...<br>
-					<sl-spinner></sl-spinner>
+					<div>
+						Use<br />
+						<span>
+							<sl-icon name="box"></sl-icon> Reconstruct
+						</span><br />
+						To perform a tomographic reconstruction on simulated projections.<br>
+					</div>
+					<div class="generating">
+						Reconstructing Volume...<br>
+						<sl-spinner></sl-spinner>
+					</div>
 				</div>
 			</div>
+			<video src="" class="image-sinogram" alt="" muted autoplay loop></video>
 		</div>
-		<div class="overlay overlay-recon update">
-			<div>
+
+		<div class="recon-recon stacker">
+			<video src="" class="image-recon" alt="" muted autoplay loop></video>
+			<div class="overlay overlay-recon update">
 				<div>
-					Use<br />
-					<span>
-						<sl-icon name="box"></sl-icon> Reconstruct
-					</span><br />
-					To perform a tomographic reconstruction on simulated projections.<br>
-				</div>
-				<div class="generating">
-					Reconstructing Volume...<br>
-					<sl-spinner></sl-spinner>
+					<div>
+						Use<br />
+						<span>
+							<sl-icon name="box"></sl-icon> Reconstruct
+						</span><br />
+						To perform a tomographic reconstruction on simulated projections.<br>
+					</div>
+					<div class="generating">
+						Reconstructing Volume...<br>
+						<sl-spinner></sl-spinner>
+					</div>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Restructure overlay components to nest and expand within a parent container, ensuring no js is needed to resize overlays.
Reconstruction preview in the preview pane has also been fixed.

|Before |After|
|--|--|
| ![image](https://user-images.githubusercontent.com/35181365/174490816-695cf3ac-3b4f-4f64-a8da-f0cca7cd5022.png)| ![image](https://user-images.githubusercontent.com/35181365/174490734-6f792d65-9588-43af-a7c2-4ee59e7c8bce.png) |

Closes #7 