### PR TITLE
feat: :sparkles: Change pixel size to μm (#14)

### DIFF
--- a/webct/blueprints/detector/static/js/detector.ts
+++ b/webct/blueprints/detector/static/js/detector.ts
@@ -103,7 +103,7 @@ function previewDetector(): void {
 		return;
 	}
 
-	const pixSize = parseFloat(PanePixelSizeElement.value);
+	const pixSize = parseFloat(PanePixelSizeElement.value) / 1000;
 	const height = Math.round(parseFloat(PaneHeightElement.value) / pixSize);
 	const width = Math.round(parseFloat(PaneWidthElement.value) / pixSize);
 	SetPreviewSize(height, width);
@@ -156,7 +156,7 @@ export function UpdateDetector(): Promise<void> {
 			// no implicit cast from number to string, really js?
 			PaneHeightElement.value = properties.paneHeight + "";
 			PaneWidthElement.value = properties.paneWidth + "";
-			PanePixelSizeElement.value = properties.pixelSize + "";
+			PanePixelSizeElement.value = properties.pixelSize * 1000 + "";
 
 			previewDetector();
 		}).catch(() => {
@@ -179,7 +179,7 @@ function setDetector(): Promise<void> {
 	const detector = prepareRequest({
 		paneHeight: parseFloat(PaneHeightElement.value),
 		paneWidth: parseFloat(PaneWidthElement.value),
-		pixelSize: parseFloat(PanePixelSizeElement.value),
+		pixelSize: parseFloat(PanePixelSizeElement.value) / 1000,
 	});
 
 	return sendDetectorData(detector).then((response: Response) => {

--- a/webct/blueprints/detector/static/js/validation.ts
+++ b/webct/blueprints/detector/static/js/validation.ts
@@ -21,10 +21,10 @@ const WidthValidator: Validator = {
 };
 
 const PixelValidator: Validator = {
-	min: 0.0001,
-	max: 100,
+	min: 0.01,
+	max: 100000,
 	type: "number",
-	message: "Pixel size must be larger than 0.001mm and less than 100mm"
+	message: "Pixel size must be larger than 0.01μm and less than 10cm (100000μm)"
 };
 
 export function validateWidth(WidthElement: SlInput): boolean {

--- a/webct/blueprints/detector/templates/tab.detector.html.j2
+++ b/webct/blueprints/detector/templates/tab.detector.html.j2
@@ -13,7 +13,7 @@
 			{% include "./units/size.html.j2" %}
 		</sl-input>
 		<sl-input type="number" label="Pixel Size" value="0.5" step="0.01" id="inputPanePixelSize">
-			{% include "./units/size.html.j2" %}
+			<span slot="suffix">μm</span>
 		</sl-input>
 
 		<sl-button style="width:95%" advanced outline disabled>Upload PSF


### PR DESCRIPTION
Change detector pixel size to use μm rather than mm, since μm is the standard for pixel pitch.
Closes #14 