### PR TITLE
fix: :bug: Reset beam type when editing capture paramaters (#27)

### DIFF
--- a/webct/components/sim/simulators/GVXRSimulator.py
+++ b/webct/components/sim/simulators/GVXRSimulator.py
@@ -162,6 +162,10 @@ class GVXRSimulator(Simulator):
 		gvxr.setDetectorPosition(*value.detector_position, "mm")
 		gvxr.setSourcePosition(*value.beam_position, "mm")
 
+		# Changing detector/source position will effect if the source is in
+		# parallel or point mode. We re-set the beam value to fix this.
+		self.beam = self._beam
+
 		# Undo rotations in order to reset scene rotation matrix
 		gvxr.rotateScene(-1 * self.total_rotation[2], 0, 0, 1)
 		gvxr.rotateScene(-1 * self.total_rotation[1], 0, 1, 0)


### PR DESCRIPTION
Changing source position resets the beam type back to point. A fix was done by re-setting the beam properties when editing capture settings.

Fixes #27