### PR TITLE
feat: :sparkles: Iterative Reconstruction Methods (#12)

### DIFF
--- a/doc/Recon_combinations.md
+++ b/doc/Recon_combinations.md
@@ -1,0 +1,15 @@
+# Reconstruction Combinations
+
+A large amount of interchangeable components are available to iterative
+reconstruction methods, however; not all work together.
+
+Below is a table of all methods, and what components they work with.
+
+
+
+| Method | Identity | Gradient |     | TotalVariation (TV)  | IndicatorBox |
+| ------ | -------- | -------- | --- | --- | ------------ |
+| FBP    |          |          |     |     |              |
+| FDK    |          |          |     |     |              |
+| CGLS   | ✔        | ✔        |     |     |              |
+| SIRT   | ✔        |          |     | ✔?   | ✔            |

--- a/doc/Recon_combinations.md
+++ b/doc/Recon_combinations.md
@@ -7,9 +7,10 @@ Below is a table of all methods, and what components they work with.
 
 
 
-| Method | Identity | Gradient |     | TotalVariation (TV)  | IndicatorBox |
-| ------ | -------- | -------- | --- | --- | ------------ |
-| FBP    |          |          |     |     |              |
-| FDK    |          |          |     |     |              |
-| CGLS   | ✔        | ✔        |     |     |              |
-| SIRT   | ✔        |          |     | ✔?   | ✔            |
+| Method | Identity | Gradient |     | TotalVariation (TV) | IndicatorBox |     | LeastSquares |
+| ------ | -------- | -------- | --- | ------------------- | ------------ | --- | ------------ |
+| FBP    |          |          |     |                     |              |     |              |
+| FDK    |          |          |     |                     |              |     |              |
+| CGLS   | ✔        | ✔        |     |                     |              |     |              |
+| SIRT   | ✔        |          |     | ✔?                  | ✔            |     |              |
+| FISTA  | -        | -        |     | -                   | -            |     | -            |

--- a/doc/Recon_combinations.md
+++ b/doc/Recon_combinations.md
@@ -7,10 +7,10 @@ Below is a table of all methods, and what components they work with.
 
 
 
-| Method | Identity | Gradient |     | TotalVariation (TV) | IndicatorBox |     | LeastSquares |
-| ------ | -------- | -------- | --- | ------------------- | ------------ | --- | ------------ |
-| FBP    |          |          |     |                     |              |     |              |
-| FDK    |          |          |     |                     |              |     |              |
-| CGLS   | ✔        | ✔        |     |                     |              |     |              |
-| SIRT   | ✔        |          |     | ✔?                  | ✔            |     |              |
-| FISTA  | -        | -        |     | -                   | -            |     | -            |
+| Method | Identity | Gradient |     | TotalVariation (TV) | IndicatorBox | FGP-TV | TGV |     | LeastSquares |
+| ------ | -------- | -------- | --- | ------------------- | ------------ | ------ | --- | --- | ------------ |
+| FBP    |          |          |     |                     |              |        |     |     |              |
+| FDK    |          |          |     |                     |              |        |     |     |              |
+| CGLS   | ✔        | ✔        |     |                     |              |        |     |     |              |
+| SIRT   | ✔        |          |     | ✔?                  | ✔            | ✔?     | ✔?  |     |              |
+| FISTA  |          |          |     | ✔                   | ✔            | ✔      | ✔   |     | ✔            |

--- a/webct/blueprints/app/static/scss/app.scss
+++ b/webct/blueprints/app/static/scss/app.scss
@@ -354,3 +354,15 @@ sl-progress-bar[variant="long"]::part(indicator) {
 .downloadPreview pre {
 	margin: 0;
 }
+
+sl-tag[size="x-small"]::part(base) {
+	font-size: 0.75rem;
+	padding: 0.2rem;
+	margin-left: 0.3rem;
+}
+
+.hidden {
+	// Force hide elements with .hidden even if display modes are overridden
+	// from higher specificity sources
+	display: none !important;
+}

--- a/webct/blueprints/app/templates/tags/cpu.html.j2
+++ b/webct/blueprints/app/templates/tags/cpu.html.j2
@@ -1,0 +1,1 @@
+<sl-tag variant="warning" pill size="x-small" slot="suffix">CPU</sl-tag>

--- a/webct/blueprints/app/templates/tags/gpu.html.j2
+++ b/webct/blueprints/app/templates/tags/gpu.html.j2
@@ -1,0 +1,1 @@
+<sl-tag variant="success" pill size="x-small" slot="suffix">GPU</sl-tag>

--- a/webct/blueprints/app/templates/tags/slow.html.j2
+++ b/webct/blueprints/app/templates/tags/slow.html.j2
@@ -1,0 +1,1 @@
+<sl-tag variant="warning" pill size="x-small" slot="suffix">Slow</sl-tag>

--- a/webct/blueprints/reconstruction/static/js/api.ts
+++ b/webct/blueprints/reconstruction/static/js/api.ts
@@ -189,7 +189,6 @@ function processDiff(data:ReconResponseRegistry["reconResponse"]):Differentiable
 			method: "least-squares",
 			params: {
 				scaling_constant: dataDiff.params.scaling_constant,
-				weight: dataDiff.params.weight,
 			}
 		} as LeastSquaresDiff;
 	default:
@@ -197,7 +196,6 @@ function processDiff(data:ReconResponseRegistry["reconResponse"]):Differentiable
 			method: "least-squares",
 			params: {
 				scaling_constant: 1,
-				weight: 1,
 			}
 		};
 	}

--- a/webct/blueprints/reconstruction/static/js/api.ts
+++ b/webct/blueprints/reconstruction/static/js/api.ts
@@ -2,7 +2,7 @@
  * api.ts : API functions for communicating between the client and server.
  * @author Iwan Mitchell
  */
-import { CGLSParams, CGLSVariant, FBPParams, FDKParams, ReconMethod, ReconQuality, ReconstructionParams, ReconstructionPreview } from "./types";
+import { CGLSParams, FBPParams, FDKParams, ReconMethod, ReconQuality, ReconstructionParams, ReconstructionPreview, TikhonovRegulariser } from "./types";
 
 // ====================================================== //
 // ====================== Endpoints ===================== //
@@ -36,7 +36,7 @@ export interface ReconResponseRegistry {
 	reconResponse: {
 		quality: ReconQuality;
 		method: ReconMethod;
-		[key: string]: string | number | boolean;
+		[key: string]: string | number | boolean | TikhonovRegulariser;
 	};
 
 	reconPreviewResponse: {
@@ -144,8 +144,16 @@ export function processResponse(data: ReconResponseRegistry[keyof ReconResponseR
 			return {
 				quality: data.quality,
 				method: data.method,
-				variant: data.variant as CGLSVariant,
-				iterations:100,
+				iterations: data.iterations,
+				tolerance: data.tolerance,
+				operator: {
+					method: (data.operator as TikhonovRegulariser).method,
+					params: {
+						alpha: (data.operator as TikhonovRegulariser).params.alpha,
+						boundary: (data.operator as TikhonovRegulariser).params.boundary,
+					},
+				} as TikhonovRegulariser,
+				// data.,
 			} as CGLSParams;
 		default:
 			break;

--- a/webct/blueprints/reconstruction/static/js/api.ts
+++ b/webct/blueprints/reconstruction/static/js/api.ts
@@ -2,7 +2,7 @@
  * api.ts : API functions for communicating between the client and server.
  * @author Iwan Mitchell
  */
-import { BoxConstraint, CGLSParams, Constraint, Differentiable, FBPParams, FDKParams, FGPTVConstraint, FISTAParams, LeastSquaresDiff, ReconMethod, ReconQuality, ReconstructionParams, ReconstructionPreview, SIRTParams, TGVConstraint, TikhonovRegulariser, TVConstraint } from "./types";
+import { BoxProximal, CGLSParams, Proximal, Differentiable, FBPParams, FDKParams, FGPTVProximal, FISTAParams, LeastSquaresDiff, ReconMethod, ReconQuality, ReconstructionParams, ReconstructionPreview, SIRTParams, TGVProximal, TikhonovRegulariser, TVProximal } from "./types";
 
 // ====================================================== //
 // ====================== Endpoints ===================== //
@@ -36,7 +36,7 @@ export interface ReconResponseRegistry {
 	reconResponse: {
 		quality: ReconQuality;
 		method: ReconMethod;
-		[key: string]: string | number | boolean | TikhonovRegulariser | Constraint | Differentiable;
+		[key: string]: string | number | boolean | TikhonovRegulariser | Proximal | Differentiable;
 	};
 
 	reconPreviewResponse: {
@@ -127,49 +127,49 @@ function processTikhonov(data:ReconResponseRegistry["reconResponse"]):TikhonovRe
 	} as TikhonovRegulariser;
 }
 
-function processConstraint(data:ReconResponseRegistry["reconResponse"]):Constraint {
-	const dataConstraint = data.constraint as Constraint;
-	switch (dataConstraint.method) {
+function processProximal(data:ReconResponseRegistry["reconResponse"]):Proximal {
+	const dataProximal = data.constraint as Proximal;
+	switch (dataProximal.method) {
 	case "box":
 		return {
-			method: dataConstraint.method,
+			method: dataProximal.method,
 			params: {
-				upper: dataConstraint.params.upper,
-				lower: dataConstraint.params.lower,
+				upper: dataProximal.params.upper,
+				lower: dataProximal.params.lower,
 			}
-		} as BoxConstraint;
+		} as BoxProximal;
 	case "tv":
 		return {
-			method: dataConstraint.method,
+			method: dataProximal.method,
 			params: {
-				isotropic: dataConstraint.params.isotropic,
-				iterations: dataConstraint.params.iterations,
-				tolerance: dataConstraint.params.tolerance,
-				lower: dataConstraint.params.lower,
-				upper: dataConstraint.params.upper,
+				isotropic: dataProximal.params.isotropic,
+				iterations: dataProximal.params.iterations,
+				tolerance: dataProximal.params.tolerance,
+				lower: dataProximal.params.lower,
+				upper: dataProximal.params.upper,
 			}
-		} as TVConstraint;
+		} as TVProximal;
 	case "fgp-tv":
 		return {
 			method: "fgp-tv",
 			params: {
-				alpha: dataConstraint.params.alpha,
-				isotropic: dataConstraint.params.isotropic,
-				iterations: dataConstraint.params.iterations,
-				nonnegativity: dataConstraint.params.nonnegativity,
-				tolerance: dataConstraint.params.tolerance,
+				alpha: dataProximal.params.alpha,
+				isotropic: dataProximal.params.isotropic,
+				iterations: dataProximal.params.iterations,
+				nonnegativity: dataProximal.params.nonnegativity,
+				tolerance: dataProximal.params.tolerance,
 			}
-		} as FGPTVConstraint;
+		} as FGPTVProximal;
 	case "tgv":
 		return {
 			method: "tgv",
 			params: {
-				alpha: dataConstraint.params.alpha,
-				gamma: dataConstraint.params.gamma,
-				iterations: dataConstraint.params.iterations,
-				tolerance: dataConstraint.params.tolerance
+				alpha: dataProximal.params.alpha,
+				gamma: dataProximal.params.gamma,
+				iterations: dataProximal.params.iterations,
+				tolerance: dataProximal.params.tolerance
 			}
-		} as TGVConstraint;
+		} as TGVProximal;
 	default:
 		return {
 			method: "box",
@@ -177,7 +177,7 @@ function processConstraint(data:ReconResponseRegistry["reconResponse"]):Constrai
 				upper: null,
 				lower: null,
 			}
-		} as BoxConstraint;
+		} as BoxProximal;
 	}
 }
 
@@ -239,14 +239,14 @@ export function processResponse(data: ReconResponseRegistry[keyof ReconResponseR
 				method: data.method,
 				iterations: data.iterations,
 				operator: processTikhonov(data),
-				constraint: processConstraint(data),
+				constraint: processProximal(data),
 			} as SIRTParams;
 		case "FISTA":
 			return {
 				quality: data.quality,
 				method: data.method,
 				iterations: data.iterations,
-				constraint: processConstraint(data),
+				constraint: processProximal(data),
 				diff: processDiff(data),
 			} as FISTAParams;
 		}

--- a/webct/blueprints/reconstruction/static/js/api.ts
+++ b/webct/blueprints/reconstruction/static/js/api.ts
@@ -2,7 +2,7 @@
  * api.ts : API functions for communicating between the client and server.
  * @author Iwan Mitchell
  */
-import { BoxConstraint, CGLSParams, Constraint, Differentiable, FBPParams, FDKParams, FISTAParams, LeastSquaresDiff, ReconMethod, ReconQuality, ReconstructionParams, ReconstructionPreview, SIRTParams, TikhonovRegulariser, TVConstraint } from "./types";
+import { BoxConstraint, CGLSParams, Constraint, Differentiable, FBPParams, FDKParams, FGPTVConstraint, FISTAParams, LeastSquaresDiff, ReconMethod, ReconQuality, ReconstructionParams, ReconstructionPreview, SIRTParams, TGVConstraint, TikhonovRegulariser, TVConstraint } from "./types";
 
 // ====================================================== //
 // ====================== Endpoints ===================== //
@@ -129,7 +129,16 @@ function processTikhonov(data:ReconResponseRegistry["reconResponse"]):TikhonovRe
 
 function processConstraint(data:ReconResponseRegistry["reconResponse"]):Constraint {
 	const dataConstraint = data.constraint as Constraint;
-	if (dataConstraint.method == "tv") {
+	switch (dataConstraint.method) {
+	case "box":
+		return {
+			method: dataConstraint.method,
+			params: {
+				upper: dataConstraint.params.upper,
+				lower: dataConstraint.params.lower,
+			}
+		} as BoxConstraint;
+	case "tv":
 		return {
 			method: dataConstraint.method,
 			params: {
@@ -140,15 +149,28 @@ function processConstraint(data:ReconResponseRegistry["reconResponse"]):Constrai
 				upper: dataConstraint.params.upper,
 			}
 		} as TVConstraint;
-	} else if (dataConstraint.method == "box") {
+	case "fgp-tv":
 		return {
-			method: dataConstraint.method,
+			method: "fgp-tv",
 			params: {
-				upper: dataConstraint.params.upper,
-				lower: dataConstraint.params.lower,
+				alpha: dataConstraint.params.alpha,
+				isotropic: dataConstraint.params.isotropic,
+				iterations: dataConstraint.params.iterations,
+				nonnegativity: dataConstraint.params.nonnegativity,
+				tolerance: dataConstraint.params.tolerance,
 			}
-		} as BoxConstraint;
-	} else {
+		} as FGPTVConstraint;
+	case "tgv":
+		return {
+			method: "tgv",
+			params: {
+				alpha: dataConstraint.params.alpha,
+				gamma: dataConstraint.params.gamma,
+				iterations: dataConstraint.params.iterations,
+				tolerance: dataConstraint.params.tolerance
+			}
+		} as TGVConstraint;
+	default:
 		return {
 			method: "box",
 			params: {

--- a/webct/blueprints/reconstruction/static/js/recon.ts
+++ b/webct/blueprints/reconstruction/static/js/recon.ts
@@ -264,9 +264,6 @@ export function setupRecon(): boolean {
 		ToggleConLower(ConCheckboxLowerElement.checked);
 	});
 
-	ToggleConUpper(ConCheckboxUpperElement.checked);
-	ToggleConLower(ConCheckboxLowerElement.checked);
-
 	TikOpElement.addEventListener("sl-change", () => {
 		switch ((TikOpElement.value as string) as TikhonovMethod) {
 		case "projection":
@@ -330,6 +327,7 @@ export function setupRecon(): boolean {
 			break;
 		case "SIRT":
 			SIRTSettings.classList.remove("hidden");
+			TikSettings.classList.remove("hidden");
 			ConSettings.classList.remove("hidden");
 			break;
 		default:
@@ -624,6 +622,7 @@ export function UpdateRecon(): Promise<void> {
 			case "SIRT":
 				params = properties as SIRTParams;
 				SIRTIterElement.value = params.iterations+"";
+				UpdateTikValues(params.operator);
 				UpdateConValues(params.constraint);
 				break;
 			}
@@ -718,6 +717,7 @@ function setRecon(): Promise<void> {
 		method: "SIRT",
 		quality: quality as ReconQuality,
 		iterations: parseInt(SIRTIterElement.value),
+		operator: Tikhonov,
 		constraint: constraint,
 	};
 

--- a/webct/blueprints/reconstruction/static/js/recon.ts
+++ b/webct/blueprints/reconstruction/static/js/recon.ts
@@ -66,7 +66,6 @@ let ConGammaElement: SlInput;
 let DiffSettings: HTMLDivElement;
 let DiffOpElement: SlSelect;
 let DiffLSScalingElement: SlInput;
-let DiffLSWeightElement: SlInput;
 
 let SliceImages: NodeListOf<HTMLVideoElement>;
 let SinogramImages: NodeListOf<HTMLVideoElement>;
@@ -158,7 +157,6 @@ export function setupRecon(): boolean {
 	const diff_settings = document.getElementById("settingsDiff");
 	const diff_select_operator = document.getElementById("selectDiffOperator");
 	const diff_input_ls_scaling = document.getElementById("inputDiffLSScaling");
-	const diff_input_ls_weight = document.getElementById("inputDiffLSWeight");
 
 	if (select_alg == null ||
 		group_alg == null ||
@@ -193,8 +191,7 @@ export function setupRecon(): boolean {
 		con_input_gamma == null ||
 		diff_settings == null ||
 		diff_select_operator == null ||
-		diff_input_ls_scaling == null ||
-		diff_input_ls_weight == null) {
+		diff_input_ls_scaling == null) {
 
 		console.log(select_alg);
 		console.log(group_alg);
@@ -237,7 +234,6 @@ export function setupRecon(): boolean {
 		console.log(diff_settings);
 		console.log(diff_select_operator);
 		console.log(diff_input_ls_scaling);
-		console.log(diff_input_ls_weight);
 
 
 		showAlert("Reconstruction setup failure", AlertType.ERROR);
@@ -296,7 +292,6 @@ export function setupRecon(): boolean {
 	DiffSettings = diff_settings as HTMLDivElement;
 	DiffOpElement = diff_select_operator as SlSelect;
 	DiffLSScalingElement = diff_input_ls_scaling as SlInput;
-	DiffLSWeightElement = diff_input_ls_weight as SlInput;
 
 	ConOpElement.addEventListener("sl-change", () => {
 
@@ -743,7 +738,6 @@ function UpdateDiffValues(params: Differentiable): void {
 	if (params.method == "least-squares") {
 		const diffLS = params as LeastSquaresDiff;
 		DiffLSScalingElement.value = diffLS.params.scaling_constant + "";
-		DiffLSWeightElement.value = diffLS.params.weight + "";
 	}
 }
 
@@ -914,7 +908,6 @@ function setRecon(): Promise<void> {
 		method: "least-squares",
 		params: {
 			scaling_constant: parseFloat(DiffLSScalingElement.value),
-			weight: parseFloat(DiffLSWeightElement.value),
 		}
 	};
 

--- a/webct/blueprints/reconstruction/static/js/recon.ts
+++ b/webct/blueprints/reconstruction/static/js/recon.ts
@@ -264,6 +264,9 @@ export function setupRecon(): boolean {
 		ToggleConLower(ConCheckboxLowerElement.checked);
 	});
 
+	ToggleConUpper(ConCheckboxUpperElement.checked);
+	ToggleConLower(ConCheckboxLowerElement.checked);
+
 	TikOpElement.addEventListener("sl-change", () => {
 		switch ((TikOpElement.value as string) as TikhonovMethod) {
 		case "projection":
@@ -327,7 +330,6 @@ export function setupRecon(): boolean {
 			break;
 		case "SIRT":
 			SIRTSettings.classList.remove("hidden");
-			TikSettings.classList.remove("hidden");
 			ConSettings.classList.remove("hidden");
 			break;
 		default:
@@ -622,7 +624,6 @@ export function UpdateRecon(): Promise<void> {
 			case "SIRT":
 				params = properties as SIRTParams;
 				SIRTIterElement.value = params.iterations+"";
-				UpdateTikValues(params.operator);
 				UpdateConValues(params.constraint);
 				break;
 			}
@@ -717,7 +718,6 @@ function setRecon(): Promise<void> {
 		method: "SIRT",
 		quality: quality as ReconQuality,
 		iterations: parseInt(SIRTIterElement.value),
-		operator: Tikhonov,
 		constraint: constraint,
 	};
 

--- a/webct/blueprints/reconstruction/static/js/types.ts
+++ b/webct/blueprints/reconstruction/static/js/types.ts
@@ -19,6 +19,16 @@ export interface FilteredReconstructionParams extends ReconstructionParams {
 	filter: Filter
 }
 
+
+export type TikhonovMethod = "projection" | "identity" | "gradient"
+export interface TikhonovRegulariser {
+	method: TikhonovMethod
+	params: {
+		alpha: number,
+		boundary: "Neumann" | "Periodic"
+	}
+}
+
 type Filter = string
 
 export interface IterativeReconstructionParams extends ReconstructionParams {
@@ -47,20 +57,23 @@ export class FBPParams implements FilteredReconstructionParams {
 	}
 }
 
-export type CGLSVariant = "" | "conv" | "tik" | "tv"
 
 export class CGLSParams implements IterativeReconstructionParams {
 	readonly method = "CGLS" as const
 	quality: ReconQuality
 	iterations: number
-	variant: CGLSVariant
+	tolerance: number
+	operator: TikhonovRegulariser
 
-	constructor(quality: ReconQuality, iterations: number, variant: CGLSVariant) {
+	constructor(quality: ReconQuality, iterations: number, tolerance:number, operator: TikhonovRegulariser) {
 		this.quality = quality;
 		this.iterations = iterations;
-		this.variant = variant;
+		this.tolerance = tolerance;
+		this.operator = operator;
 	}
 }
+
+
 
 export interface ReconstructionPreview {
 	recon: {

--- a/webct/blueprints/reconstruction/static/js/types.ts
+++ b/webct/blueprints/reconstruction/static/js/types.ts
@@ -5,7 +5,7 @@
 
 export type ReconMethod = "FDK" | "FBP" | "CGLS" | "MLEM" | "SIRT" | "FISTA"
 export type TikhonovMethod = "projection" | "identity" | "gradient"
-export type ConstraintMethod = "box" | "tv" | "fgp-tv" | "tgv"
+export type ProximalMethod = "box" | "tv" | "fgp-tv" | "tgv"
 export type DiffMethod = "least-squares"
 
 export type ReconQuality = 0 | 1 | 2 | 3
@@ -28,14 +28,14 @@ export interface TikhonovRegulariser {
 	}
 }
 
-export interface Constraint {
-	method: ConstraintMethod
+export interface Proximal {
+	method: ProximalMethod
 	params: {
 		[key: string]: string | number | null | boolean
 	}
 }
 
-export interface BoxConstraint extends Constraint {
+export interface BoxProximal extends Proximal {
 	readonly method: "box"
 	params: {
 		lower: number|null
@@ -43,7 +43,7 @@ export interface BoxConstraint extends Constraint {
 	}
 }
 
-export interface TVConstraint extends Constraint {
+export interface TVProximal extends Proximal {
 	readonly method: "tv",
 	params: {
 		iterations: number,
@@ -55,7 +55,7 @@ export interface TVConstraint extends Constraint {
 	}
 }
 
-export interface FGPTVConstraint extends Constraint {
+export interface FGPTVProximal extends Proximal {
 	readonly method: "fgp-tv"
 	params: {
 		iterations: number,
@@ -66,7 +66,7 @@ export interface FGPTVConstraint extends Constraint {
 	}
 }
 
-export interface TGVConstraint extends Constraint {
+export interface TGVProximal extends Proximal {
 	readonly method: "tgv"
 	params: {
 		iterations: number,
@@ -138,10 +138,10 @@ export class SIRTParams implements IterativeReconstructionParams {
 	readonly method = "SIRT" as const
 	quality:ReconQuality
 	iterations:number
-	constraint: Constraint
+	constraint: Proximal
 	operator: TikhonovRegulariser
 
-	constructor(quality:ReconQuality, iterations:number, constraint:Constraint, operator:TikhonovRegulariser) {
+	constructor(quality:ReconQuality, iterations:number, constraint:Proximal, operator:TikhonovRegulariser) {
 		this.quality = quality;
 		this.iterations = iterations;
 		this.constraint = constraint;
@@ -153,10 +153,10 @@ export class FISTAParams implements IterativeReconstructionParams {
 	readonly method = "FISTA" as const
 	quality:ReconQuality
 	iterations: number
-	constraint: Constraint
+	constraint: Proximal
 	diff:Differentiable
 
-	constructor(quality:ReconQuality, iterations:number, constriant:Constraint, diff:Differentiable) {
+	constructor(quality:ReconQuality, iterations:number, constriant:Proximal, diff:Differentiable) {
 		this.quality = quality;
 		this.iterations = iterations;
 		this.constraint = constriant;

--- a/webct/blueprints/reconstruction/static/js/types.ts
+++ b/webct/blueprints/reconstruction/static/js/types.ts
@@ -5,7 +5,7 @@
 
 export type ReconMethod = "FDK" | "FBP" | "CGLS" | "MLEM" | "SIRT" | "FISTA"
 export type TikhonovMethod = "projection" | "identity" | "gradient"
-export type ConstraintMethod = "box" | "tv"
+export type ConstraintMethod = "box" | "tv" | "fgp-tv" | "tgv"
 export type DiffMethod = "least-squares"
 
 export type ReconQuality = 0 | 1 | 2 | 3
@@ -52,6 +52,27 @@ export interface TVConstraint extends Constraint {
 		isotropic: boolean,
 		lower: number|null,
 		upper: number|null,
+	}
+}
+
+export interface FGPTVConstraint extends Constraint {
+	readonly method: "fgp-tv"
+	params: {
+		iterations: number,
+		alpha: number,
+		tolerance: number,
+		isotropic: boolean,
+		nonnegativity: boolean,
+	}
+}
+
+export interface TGVConstraint extends Constraint {
+	readonly method: "tgv"
+	params: {
+		iterations: number,
+		alpha: number,
+		gamma: number,
+		tolerance: number,
 	}
 }
 

--- a/webct/blueprints/reconstruction/static/js/types.ts
+++ b/webct/blueprints/reconstruction/static/js/types.ts
@@ -87,7 +87,6 @@ export interface LeastSquaresDiff {
 	readonly method: "least-squares"
 	params: {
 		scaling_constant: number,
-		weight: number
 	}
 }
 

--- a/webct/blueprints/reconstruction/static/js/types.ts
+++ b/webct/blueprints/reconstruction/static/js/types.ts
@@ -105,13 +105,11 @@ export class SIRTParams implements IterativeReconstructionParams {
 	quality:ReconQuality
 	iterations:number
 	constraint: Constraint
-	operator: TikhonovRegulariser
 
-	constructor(quality:ReconQuality, iterations:number, constraint:Constraint, operator:TikhonovRegulariser) {
+	constructor(quality:ReconQuality, iterations:number, constraint:Constraint) {
 		this.quality = quality;
 		this.iterations = iterations;
 		this.constraint = constraint;
-		this.operator = operator;
 	}
 }
 

--- a/webct/blueprints/reconstruction/static/js/types.ts
+++ b/webct/blueprints/reconstruction/static/js/types.ts
@@ -3,10 +3,10 @@
  * @author Iwan Mitchell
  */
 
-/**
- * Supported reconstruction algorithms.
- */
-export type ReconMethod = "FDK" | "FBP" | "CGLS" | "MLEM" | "SIRT"
+export type ReconMethod = "FDK" | "FBP" | "CGLS" | "MLEM" | "SIRT" | "FISTA"
+export type TikhonovMethod = "projection" | "identity" | "gradient"
+export type ConstraintMethod = "box" | "tv"
+export type DiffMethod = "least-squares"
 
 export type ReconQuality = 0 | 1 | 2 | 3
 
@@ -20,7 +20,6 @@ export interface FilteredReconstructionParams extends ReconstructionParams {
 }
 
 
-export type TikhonovMethod = "projection" | "identity" | "gradient"
 export interface TikhonovRegulariser {
 	method: TikhonovMethod
 	params: {
@@ -29,7 +28,6 @@ export interface TikhonovRegulariser {
 	}
 }
 
-export type ConstraintMethod = "box" | "tv"
 export interface Constraint {
 	method: ConstraintMethod
 	params: {
@@ -54,6 +52,21 @@ export interface TVConstraint extends Constraint {
 		isotropic: boolean,
 		lower: number|null,
 		upper: number|null,
+	}
+}
+
+export interface Differentiable {
+	method: DiffMethod,
+	params: {
+		[key: string]: string | number | boolean
+	}
+}
+
+export interface LeastSquaresDiff {
+	readonly method: "least-squares"
+	params: {
+		scaling_constant: number,
+		weight: number
 	}
 }
 
@@ -116,6 +129,20 @@ export class SIRTParams implements IterativeReconstructionParams {
 	}
 }
 
+export class FISTAParams implements IterativeReconstructionParams {
+	readonly method = "FISTA" as const
+	quality:ReconQuality
+	iterations: number
+	constraint: Constraint
+	diff:Differentiable
+
+	constructor(quality:ReconQuality, iterations:number, constriant:Constraint, diff:Differentiable) {
+		this.quality = quality;
+		this.iterations = iterations;
+		this.constraint = constriant;
+		this.diff = diff;
+	}
+}
 
 export interface ReconstructionPreview {
 	recon: {

--- a/webct/blueprints/reconstruction/static/js/types.ts
+++ b/webct/blueprints/reconstruction/static/js/types.ts
@@ -29,6 +29,33 @@ export interface TikhonovRegulariser {
 	}
 }
 
+export type ConstraintMethod = "box" | "tv"
+export interface Constraint {
+	method: ConstraintMethod
+	params: {
+		[key: string]: string | number | null | boolean
+	}
+}
+
+export interface BoxConstraint extends Constraint {
+	readonly method: "box"
+	params: {
+		lower: number|null
+		upper: number|null
+	}
+}
+
+export interface TVConstraint extends Constraint {
+	readonly method: "tv",
+	params: {
+		iterations: number,
+		tolerance: number,
+		isotropic: boolean,
+		lower: number|null,
+		upper: number|null,
+	}
+}
+
 type Filter = string
 
 export interface IterativeReconstructionParams extends ReconstructionParams {
@@ -73,6 +100,20 @@ export class CGLSParams implements IterativeReconstructionParams {
 	}
 }
 
+export class SIRTParams implements IterativeReconstructionParams {
+	readonly method = "SIRT" as const
+	quality:ReconQuality
+	iterations:number
+	constraint: Constraint
+	operator: TikhonovRegulariser
+
+	constructor(quality:ReconQuality, iterations:number, constraint:Constraint, operator:TikhonovRegulariser) {
+		this.quality = quality;
+		this.iterations = iterations;
+		this.constraint = constraint;
+		this.operator = operator;
+	}
+}
 
 
 export interface ReconstructionPreview {

--- a/webct/blueprints/reconstruction/static/js/types.ts
+++ b/webct/blueprints/reconstruction/static/js/types.ts
@@ -49,6 +49,7 @@ export interface TVConstraint extends Constraint {
 	readonly method: "tv",
 	params: {
 		iterations: number,
+		alpha: number,
 		tolerance: number,
 		isotropic: boolean,
 		lower: number|null,

--- a/webct/blueprints/reconstruction/static/js/types.ts
+++ b/webct/blueprints/reconstruction/static/js/types.ts
@@ -105,11 +105,13 @@ export class SIRTParams implements IterativeReconstructionParams {
 	quality:ReconQuality
 	iterations:number
 	constraint: Constraint
+	operator: TikhonovRegulariser
 
-	constructor(quality:ReconQuality, iterations:number, constraint:Constraint) {
+	constructor(quality:ReconQuality, iterations:number, constraint:Constraint, operator:TikhonovRegulariser) {
 		this.quality = quality;
 		this.iterations = iterations;
 		this.constraint = constraint;
+		this.operator = operator;
 	}
 }
 

--- a/webct/blueprints/reconstruction/static/scss/recon.scss
+++ b/webct/blueprints/reconstruction/static/scss/recon.scss
@@ -27,8 +27,9 @@ div.group > div > div.check-property {
 }
 
 div.check-property > sl-checkbox {
-	align-self: center;
+	align-self: end;
 	justify-self: center;
+	margin-bottom: 50%;
 }
 
 div.stacker {

--- a/webct/blueprints/reconstruction/static/scss/recon.scss
+++ b/webct/blueprints/reconstruction/static/scss/recon.scss
@@ -21,6 +21,16 @@
 	width: 100%;
 }
 
+div.group > div > div.check-property {
+	display: grid;
+	grid-template-columns: 10% 90%;
+}
+
+div.check-property > sl-checkbox {
+	align-self: center;
+	justify-self: center;
+}
+
 div.stacker {
 	// 1x1 grid with a named area
 	grid-template-areas: "t1";

--- a/webct/blueprints/reconstruction/templates/tab.reconstruction.html.j2
+++ b/webct/blueprints/reconstruction/templates/tab.reconstruction.html.j2
@@ -87,9 +87,9 @@
 			<sl-checkbox id="checkboxConLower"></sl-checkbox>
 			<sl-input type="number" id="inputConLower" label="Lower Constraint" value="0"></sl-input>
 		</div>
-		<sl-input id="inputConTVIterations" type="number" label="Iterations" step=1 min=1 advanced></sl-input>
-		<sl-checkbox id="checkboxConTVIsotropic" advanced>Isotropic</sl-checkbox>
-		<sl-input type="number" label="Tolerance" step=1 min=1 value="1" id="inputConTVTolerance" advanced><span slot="suffix">e-6</span></sl-input>
+		<sl-input id="inputConTVIterations" type="number" label="Iterations" step=1 min=1 advanced disabled></sl-input>
+		<sl-checkbox id="checkboxConTVIsotropic" advanced disabled>Isotropic</sl-checkbox>
+		<sl-input type="number" label="Tolerance" step=1 min=1 value="1" id="inputConTVTolerance" advanced disabled><span slot="suffix">e-6</span></sl-input>
 	</div>
 	<button></button>
 </div>

--- a/webct/blueprints/reconstruction/templates/tab.reconstruction.html.j2
+++ b/webct/blueprints/reconstruction/templates/tab.reconstruction.html.j2
@@ -112,7 +112,6 @@
 			<sl-menu-item value="least-squares">Least Squares</sl-menu-item>
 		</sl-select>
 		<sl-input type="number" step="0.1" value="1" id="inputDiffLSScaling" label="Scaling Constant" advanced></sl-input>
-		<sl-input type="number" step="0.1" value="1" id="inputDiffLSWeight" label="Weight" advanced></sl-input>
 	</div>
 	<button></button>
 </div>
@@ -124,7 +123,7 @@
 				<span><br>Upper & Lower Bounds</span>
 			</sl-menu-item>
 			<sl-menu-item value="tv">Total Variation
-				{% include "./tags/slow.html.j2" %}
+				{% include "./tags/cpu.html.j2" %}
 			</sl-menu-item>
 			<sl-menu-item value="fgp-tv">FGP-TV
 				<span> Fast Gradient Projection Total Variation</span>
@@ -132,7 +131,7 @@
 			</sl-menu-item>
 			<sl-menu-item value="tgv">TGV
 				<span> Total Generalised Variation</span>
-				{% include "./tags/slow.html.j2" %}
+				{% include "./tags/cpu.html.j2" %}
 			</sl-menu-item>
 		</sl-select>
 
@@ -149,7 +148,7 @@
 		<sl-input id="inputConIterations" type="number" label="Iterations" step=1 min=1 value="10" disabled>
 		</sl-input>
 
-		<sl-checkbox id="checkboxConNonNeg" checked disabled>Non- negativity</sl-checkbox>
+		<sl-checkbox id="checkboxConNonNeg" checked disabled>Non-negativity</sl-checkbox>
 
 		<sl-input type="number" label="Alpha" step=0.01 min=0 value="0.1" id="inputConAlpha" advanced disabled>
 		</sl-input>

--- a/webct/blueprints/reconstruction/templates/tab.reconstruction.html.j2
+++ b/webct/blueprints/reconstruction/templates/tab.reconstruction.html.j2
@@ -87,9 +87,9 @@
 			<sl-checkbox id="checkboxConLower"></sl-checkbox>
 			<sl-input type="number" id="inputConLower" label="Lower Constraint" value="0"></sl-input>
 		</div>
-		<sl-input id="inputConTVIterations" type="number" label="Iterations" step=1 min=1 advanced disabled></sl-input>
-		<sl-checkbox id="checkboxConTVIsotropic" advanced disabled>Isotropic</sl-checkbox>
-		<sl-input type="number" label="Tolerance" step=1 min=1 value="1" id="inputConTVTolerance" advanced disabled><span slot="suffix">e-6</span></sl-input>
+		<sl-input id="inputConTVIterations" type="number" label="Iterations" step=1 min=1 advanced></sl-input>
+		<sl-checkbox id="checkboxConTVIsotropic" advanced>Isotropic</sl-checkbox>
+		<sl-input type="number" label="Tolerance" step=1 min=1 value="1" id="inputConTVTolerance" advanced><span slot="suffix">e-6</span></sl-input>
 	</div>
 	<button></button>
 </div>

--- a/webct/blueprints/reconstruction/templates/tab.reconstruction.html.j2
+++ b/webct/blueprints/reconstruction/templates/tab.reconstruction.html.j2
@@ -18,9 +18,9 @@
 			<sl-menu-item value="FBP">FBP<span> Filtered Back Projection</span></sl-menu-item>
 			<sl-divider></sl-divider>
 			<sl-menu-label>Iterative Methods</sl-menu-label>
-			<sl-menu-item value="MLEM">MLEM<span> Maximum Likelihood Estimation Method</span></sl-menu-item>
-			<sl-menu-item value="SIRT">SIRT<span> Simultaneous Iterative Reconstructive Technique</span></sl-menu-item>
 			<sl-menu-item value="CGLS">CGLS<span> Conjugate Gradient Least Squares</span></sl-menu-item>
+			<sl-menu-item value="MLEM" disabled>MLEM<span> Maximum Likelihood Estimation Method</span></sl-menu-item>
+			<sl-menu-item value="SIRT" disabled>SIRT<span> Simultaneous Iterative Reconstructive Technique</span></sl-menu-item>
 		</sl-select>
 		<sl-select label="Reconstruction Quality" value="medium" id="selectReconQuality" advanced>
 			<sl-menu-item value="0">High
@@ -59,24 +59,40 @@
 <div class="group hidden" id="settingsCGLS">
 	<div>
 		<h2>CGLS Settings</h2>
-		<sl-select label="CGLS Variant" id="selectVariantCGLS" class="hidden" value="">
-			<sl-menu-item value="">No Varient</sl-menu-item>
-			<sl-menu-item value="Conv">Convolution</sl-menu-item>
-			<sl-menu-item value="Tik">Tikhonov Regularization</sl-menu-item>
-			<sl-menu-item value="TV">TV Regularisation<span> Total Variation</span></sl-menu-item>
-		</sl-select>
+		<sl-input type="number" label="Iterations" step=1 min=1 value="5" id="inputCGLSIterations"></sl-input>
+		<sl-input type="number" label="Tolerance" step=1 min=1 value="1" id="inputCGLSTolerance"><span slot="suffix">e-6</span></sl-input>
 	</div>
 	<!-- <button></button> -->
 </div>
 
-<div class="group" id="settingsOperator">
+<div class="group hidden" id="settingsSIRT">
 	<div>
-		<sl-select label="Iterative Operator" id="selectIterativeOperator" class="" value="">
-			<sl-menu-item value="projection">Projection Operator<span>No Regularisation</span></sl-menu-item>
+		<h2>SIRT Settings</h2>
+		<sl-input type="number" label="Iterations" step=1 min=1 value="5"></sl-input>
+		<div class="check-property">
+		<sl-checkbox></sl-checkbox>
+		<sl-input type="number" label="Upper Constraint" step=1 min=1 value="5"></sl-input>
+		</div>
+		<div class="check-property">
+		<sl-checkbox></sl-checkbox>
+		<sl-input type="number" label="Lower Constraint" step=1 min=1 value="5"></sl-input>
+		</div>
+	</div>
+	<!-- <button></button> -->
+</div>
+
+<div class="group" id="settingsTikhonov">
+	<div>
+		<sl-select label="Tikhonov Regularization Operator" id="selectTikOperator" class="" value="projection">
+			<sl-menu-item value="projection">Projection Operator<span><br>No Regularisation</span></sl-menu-item>
 			<sl-menu-item value="identity">Identity Operator</sl-menu-item>
 			<sl-menu-item value="gradient">Gradient Operator</sl-menu-item>
 		</sl-select>
-		<sl-input type="number" label="alpha"></sl-input>
+		<sl-input type="number" label="Alpha" value="0.1" id="inputTikAlpha"></sl-input>
+		<sl-select label="Boundary Condition" advanced value="Neumann" id="selectTikBoundary">
+			<sl-menu-item value="Neumann">Neumann</sl-menu-item>
+			<sl-menu-item value="Periodic">Periodic</sl-menu-item>
+		</sl-select>
 	</div>
-	<!-- <button></button> -->
+	<button></button>
 </div>

--- a/webct/blueprints/reconstruction/templates/tab.reconstruction.html.j2
+++ b/webct/blueprints/reconstruction/templates/tab.reconstruction.html.j2
@@ -14,17 +14,17 @@
 		<sl-select label="Reconstruction Algorithm" value="FDK" id="selectReconstruction">
 			<sl-menu-label>Non-Iterative</sl-menu-label>
 			{# Span elements do not show up when selected.#}
-			<sl-menu-item value="FDK">FDK<span> Feldkamp, David & Kress</span></sl-menu-item>
-			<sl-menu-item value="FBP">FBP<span> Filtered Back Projection</span></sl-menu-item>
+			<sl-menu-item value="FDK">FDK<span><sl-tag variant="success" pill size="small">GPU</sl-tag> Feldkamp, David & Kress</span></sl-menu-item>
+			<sl-menu-item value="FBP">FBP<span><sl-tag variant="success" pill size="small">GPU</sl-tag> Filtered Back Projection</span></sl-menu-item>
 			<sl-divider></sl-divider>
 			<sl-menu-label>Iterative Methods</sl-menu-label>
-			<sl-menu-item value="CGLS">CGLS<span> Conjugate Gradient Least Squares</span></sl-menu-item>
-			<sl-menu-item value="MLEM" disabled>MLEM<span> Maximum Likelihood Estimation Method</span></sl-menu-item>
-			<sl-menu-item value="SIRT" disabled>SIRT<span> Simultaneous Iterative Reconstructive Technique</span></sl-menu-item>
+			<sl-menu-item value="CGLS">CGLS<span><sl-tag variant="warning" pill size="small">CPU</sl-tag> Conjugate Gradient Least Squares</span></sl-menu-item>
+			<sl-menu-item value="SIRT">SIRT<span><sl-tag variant="warning" pill size="small">CPU</sl-tag> Simultaneous Iterative Reconstructive Technique</span></sl-menu-item>
+			<sl-menu-item value="MLEM" disabled>MLEM<span><sl-tag variant="success" pill size="small">GPU</sl-tag> Maximum Likelihood Estimation Method</span></sl-menu-item>
 		</sl-select>
 		<sl-select label="Reconstruction Quality" value="medium" id="selectReconQuality" advanced>
 			<sl-menu-item value="0">High
-				<sl-tag slot="suffix" variant="danger" pill size="small">GPU Intensive</sl-pill>
+				<sl-tag slot="suffix" variant="danger" pill size="small">Memory Intensive</sl-tag>
 			</sl-menu-item>
 			<sl-menu-item value="1">Medium</sl-menu-item>
 			<sl-menu-item value="2">Low</sl-menu-item>
@@ -60,25 +60,38 @@
 	<div>
 		<h2>CGLS Settings</h2>
 		<sl-input type="number" label="Iterations" step=1 min=1 value="5" id="inputCGLSIterations"></sl-input>
-		<sl-input type="number" label="Tolerance" step=1 min=1 value="1" id="inputCGLSTolerance"><span slot="suffix">e-6</span></sl-input>
+		<sl-input type="number" label="Tolerance" step=1 min=1 value="1" id="inputCGLSTolerance" advanced><span slot="suffix">e-6</span></sl-input>
 	</div>
-	<!-- <button></button> -->
+	<button></button>
 </div>
 
 <div class="group hidden" id="settingsSIRT">
 	<div>
 		<h2>SIRT Settings</h2>
-		<sl-input type="number" label="Iterations" step=1 min=1 value="5"></sl-input>
-		<div class="check-property">
-		<sl-checkbox></sl-checkbox>
-		<sl-input type="number" label="Upper Constraint" step=1 min=1 value="5"></sl-input>
-		</div>
-		<div class="check-property">
-		<sl-checkbox></sl-checkbox>
-		<sl-input type="number" label="Lower Constraint" step=1 min=1 value="5"></sl-input>
-		</div>
+		<sl-input type="number" id="inputSIRTIterations" label="Iterations" step=1 min=1 value="5"></sl-input>
 	</div>
 	<!-- <button></button> -->
+</div>
+
+<div class="group" id="settingsConstraint">
+	<div>
+		<sl-select label="Reconstruction Constraint" id="selectConOperator" class="" value="box">
+			<sl-menu-item value="box">Indicator Box<span><br>Upper & Lower Bounds</span></sl-menu-item>
+			<sl-menu-item value="tv">Total Variation</sl-menu-item>
+		</sl-select>
+		<div class="check-property">
+			<sl-checkbox id="checkboxConUpper"></sl-checkbox>
+			<sl-input type="number" id="inputConUpper" label="Upper Constraint" value="5"></sl-input>
+		</div>
+		<div class="check-property">
+			<sl-checkbox id="checkboxConLower"></sl-checkbox>
+			<sl-input type="number" id="inputConLower" label="Lower Constraint" value="0"></sl-input>
+		</div>
+		<sl-input id="inputConTVIterations" type="number" label="Iterations" step=1 min=1 advanced></sl-input>
+		<sl-checkbox id="checkboxConTVIsotropic" advanced>Isotropic</sl-checkbox>
+		<sl-input type="number" label="Tolerance" step=1 min=1 value="1" id="inputConTVTolerance" advanced><span slot="suffix">e-6</span></sl-input>
+	</div>
+	<button></button>
 </div>
 
 <div class="group" id="settingsTikhonov">

--- a/webct/blueprints/reconstruction/templates/tab.reconstruction.html.j2
+++ b/webct/blueprints/reconstruction/templates/tab.reconstruction.html.j2
@@ -106,6 +106,17 @@
 	<!-- <button></button> -->
 </div>
 
+<div class="group" id="settingsDiff">
+	<div>
+		<sl-select label="Differentiable Function" id="selectDiffOperator" value="least-squares">
+			<sl-menu-item value="least-squares">Least Squares</sl-menu-item>
+		</sl-select>
+		<sl-input type="number" step="0.1" value="1" id="inputDiffLSScaling" label="Scaling Constant" advanced></sl-input>
+		<sl-input type="number" step="0.1" value="1" id="inputDiffLSWeight" label="Weight" advanced></sl-input>
+	</div>
+	<button></button>
+</div>
+
 <div class="group" id="settingsConstraint">
 	<div>
 		<sl-select label="Reconstruction Constraint" id="selectConOperator" class="" value="box">
@@ -113,6 +124,14 @@
 				<span><br>Upper & Lower Bounds</span>
 			</sl-menu-item>
 			<sl-menu-item value="tv">Total Variation
+				{% include "./tags/slow.html.j2" %}
+			</sl-menu-item>
+			<sl-menu-item value="fgp-tv">FGP-TV
+				<span> Fast Gradient Projection Total Variation</span>
+				{% include "./tags/gpu.html.j2" %}
+			</sl-menu-item>
+			<sl-menu-item value="tgv">TGV
+				<span> Total Generalised Variation</span>
 				{% include "./tags/slow.html.j2" %}
 			</sl-menu-item>
 		</sl-select>
@@ -127,12 +146,20 @@
 			<sl-input type="number" id="inputConLower" label="Lower Constraint" value="0"></sl-input>
 		</div>
 
-		<sl-input id="inputConTVIterations" type="number" label="Iterations" step=1 min=1 value="10" disabled>
+		<sl-input id="inputConIterations" type="number" label="Iterations" step=1 min=1 value="10" disabled>
 		</sl-input>
-		<sl-input type="number" label="Alpha" step=0.01 min=0 value="0.1" id="inputConTVAlpha" advanced disabled>
+
+		<sl-checkbox id="checkboxConNonNeg" checked disabled>Non- negativity</sl-checkbox>
+
+		<sl-input type="number" label="Alpha" step=0.01 min=0 value="0.1" id="inputConAlpha" advanced disabled>
 		</sl-input>
-		<sl-checkbox id="checkboxConTVIsotropic" checked advanced disabled>Isotropic</sl-checkbox>
-		<sl-input type="number" label="Tolerance" step=1 min=1 value="1" id="inputConTVTolerance" advanced disabled>
+
+		<sl-input type="number" label="Gamma" step=0.01 min=0 value="1" id="inputConGamma" advanced disabled>
+		</sl-input>
+
+		<sl-checkbox id="checkboxConIsotropic" checked advanced disabled>Isotropic</sl-checkbox>
+
+		<sl-input type="number" label="Tolerance" step=1 min=1 value="1" id="inputConTolerance" advanced disabled>
 			<span slot="suffix">e-6</span></sl-input>
 	</div>
 	<button></button>
@@ -150,17 +177,6 @@
 			<sl-menu-item value="Neumann">Neumann</sl-menu-item>
 			<sl-menu-item value="Periodic">Periodic</sl-menu-item>
 		</sl-select>
-	</div>
-	<button></button>
-</div>
-
-<div class="group" id="settingsDiff">
-	<div>
-		<sl-select label="Differentiable Function" id="selectDiffOperator" value="least-squares">
-			<sl-menu-item value="least-squares">Least Squares</sl-menu-item>
-		</sl-select>
-		<sl-input type="number" step="0.1" value="1" id="inputDiffLSScaling" label="Scaling Constant" advanced></sl-input>
-		<sl-input type="number" step="0.1" value="1" id="inputDiffLSWeight" label="Weight" advanced></sl-input>
 	</div>
 	<button></button>
 </div>

--- a/webct/blueprints/reconstruction/templates/tab.reconstruction.html.j2
+++ b/webct/blueprints/reconstruction/templates/tab.reconstruction.html.j2
@@ -13,15 +13,38 @@
 	<div>
 		<sl-select label="Reconstruction Algorithm" value="FDK" id="selectReconstruction">
 			<sl-menu-label>Non-Iterative</sl-menu-label>
-			{# Span elements do not show up when selected.#}
-			<sl-menu-item value="FDK">FDK<span><sl-tag variant="success" pill size="small">GPU</sl-tag> Feldkamp, David & Kress</span></sl-menu-item>
-			<sl-menu-item value="FBP">FBP<span><sl-tag variant="success" pill size="small">GPU</sl-tag> Filtered Back Projection</span></sl-menu-item>
+
+			{# Span elements do not show up when selected,#}
+			{# they make for good descriptive text. #}
+			<sl-menu-item value="FDK">FDK
+				<span> Feldkamp, David & Kress</span>
+				{% include "./tags/gpu.html.j2" %}
+			</sl-menu-item>
+
+			<sl-menu-item value="FBP">FBP
+				<span> Filtered Back Projection</span>
+				{% include "./tags/gpu.html.j2" %}
+			</sl-menu-item>
+
 			<sl-divider></sl-divider>
 			<sl-menu-label>Iterative Methods</sl-menu-label>
-			<sl-menu-item value="CGLS">CGLS<span><sl-tag variant="warning" pill size="small">CPU</sl-tag> Conjugate Gradient Least Squares</span></sl-menu-item>
-			<sl-menu-item value="SIRT">SIRT<span><sl-tag variant="warning" pill size="small">CPU</sl-tag> Simultaneous Iterative Reconstructive Technique</span></sl-menu-item>
-			<sl-menu-item value="MLEM" disabled>MLEM<span><sl-tag variant="success" pill size="small">GPU</sl-tag> Maximum Likelihood Estimation Method</span></sl-menu-item>
+
+			<sl-menu-item value="CGLS">CGLS
+				<span> Conjugate Gradient Least Squares</span>
+				{% include "./tags/cpu.html.j2" %}
+			</sl-menu-item>
+
+			<sl-menu-item value="SIRT">SIRT
+				<span> Simultaneous Iterative Reconstructive Technique</span>
+				{% include "./tags/cpu.html.j2" %}
+			</sl-menu-item>
+
+			<sl-menu-item value="MLEM" disabled>MLEM
+				<span>Maximum Likelihood Estimation Method</span>
+				{% include "./tags/cpu.html.j2" %}
+			</sl-menu-item>
 		</sl-select>
+
 		<sl-select label="Reconstruction Quality" value="medium" id="selectReconQuality" advanced>
 			<sl-menu-item value="0">High
 				<sl-tag slot="suffix" variant="danger" pill size="small">Memory Intensive</sl-tag>
@@ -76,20 +99,28 @@
 <div class="group" id="settingsConstraint">
 	<div>
 		<sl-select label="Reconstruction Constraint" id="selectConOperator" class="" value="box">
-			<sl-menu-item value="box">Indicator Box<span><br>Upper & Lower Bounds</span></sl-menu-item>
-			<sl-menu-item value="tv">Total Variation</sl-menu-item>
+			<sl-menu-item value="box">Indicator Box
+				<span><br>Upper & Lower Bounds</span>
+			</sl-menu-item>
+			<sl-menu-item value="tv">Total Variation
+				{% include "./tags/slow.html.j2" %}
+			</sl-menu-item>
 		</sl-select>
-		<div class="check-property">
+
+		<div class="check-property" advanced>
 			<sl-checkbox id="checkboxConUpper"></sl-checkbox>
 			<sl-input type="number" id="inputConUpper" label="Upper Constraint" value="5"></sl-input>
 		</div>
+
 		<div class="check-property">
 			<sl-checkbox id="checkboxConLower"></sl-checkbox>
 			<sl-input type="number" id="inputConLower" label="Lower Constraint" value="0"></sl-input>
 		</div>
-		<sl-input id="inputConTVIterations" type="number" label="Iterations" step=1 min=1 advanced></sl-input>
-		<sl-checkbox id="checkboxConTVIsotropic" advanced>Isotropic</sl-checkbox>
-		<sl-input type="number" label="Tolerance" step=1 min=1 value="1" id="inputConTVTolerance" advanced><span slot="suffix">e-6</span></sl-input>
+
+		<sl-input id="inputConTVIterations" type="number" label="Iterations" step=1 min=1 value="10" disabled></sl-input>
+		<sl-input type="number" label="Alpha" step=0.01 min=0 value="0.1" id="inputConTVAlpha" advanced disabled></sl-input>
+		<sl-checkbox id="checkboxConTVIsotropic" checked advanced disabled>Isotropic</sl-checkbox>
+		<sl-input type="number" label="Tolerance" step=1 min=1 value="1" id="inputConTVTolerance" advanced disabled><span slot="suffix">e-6</span></sl-input>
 	</div>
 	<button></button>
 </div>
@@ -101,8 +132,8 @@
 			<sl-menu-item value="identity">Identity Operator</sl-menu-item>
 			<sl-menu-item value="gradient">Gradient Operator</sl-menu-item>
 		</sl-select>
-		<sl-input type="number" label="Alpha" value="0.1" id="inputTikAlpha"></sl-input>
-		<sl-select label="Boundary Condition" advanced value="Neumann" id="selectTikBoundary">
+		<sl-input type="number" label="Alpha" value="0.1" disabled id="inputTikAlpha"></sl-input>
+		<sl-select label="Boundary Condition" advanced disabled value="Neumann" id="selectTikBoundary">
 			<sl-menu-item value="Neumann">Neumann</sl-menu-item>
 			<sl-menu-item value="Periodic">Periodic</sl-menu-item>
 		</sl-select>

--- a/webct/blueprints/reconstruction/templates/tab.reconstruction.html.j2
+++ b/webct/blueprints/reconstruction/templates/tab.reconstruction.html.j2
@@ -18,9 +18,9 @@
 			<sl-menu-item value="FBP">FBP<span> Filtered Back Projection</span></sl-menu-item>
 			<sl-divider></sl-divider>
 			<sl-menu-label>Iterative Methods</sl-menu-label>
-			<sl-menu-item value="MLEM" disabled>MLEM<span> Maximum Likelihood Estimation Method</span></sl-menu-item>
-			<sl-menu-item value="SIRT" disabled>SIRT<span> Simultaneous Iterative Reconstructive Technique</span></sl-menu-item>
-			<sl-menu-item value="CGLS" disabled>CGLS<span> Conjugate Gradient Least Squares</span></sl-menu-item>
+			<sl-menu-item value="MLEM">MLEM<span> Maximum Likelihood Estimation Method</span></sl-menu-item>
+			<sl-menu-item value="SIRT">SIRT<span> Simultaneous Iterative Reconstructive Technique</span></sl-menu-item>
+			<sl-menu-item value="CGLS">CGLS<span> Conjugate Gradient Least Squares</span></sl-menu-item>
 		</sl-select>
 		<sl-select label="Reconstruction Quality" value="medium" id="selectReconQuality" advanced>
 			<sl-menu-item value="0">High
@@ -62,9 +62,21 @@
 		<sl-select label="CGLS Variant" id="selectVariantCGLS" class="hidden" value="">
 			<sl-menu-item value="">No Varient</sl-menu-item>
 			<sl-menu-item value="Conv">Convolution</sl-menu-item>
-			<sl-menu-item value="Tik"> Tikhonov Regularization</sl-menu-item>
+			<sl-menu-item value="Tik">Tikhonov Regularization</sl-menu-item>
 			<sl-menu-item value="TV">TV Regularisation<span> Total Variation</span></sl-menu-item>
 		</sl-select>
+	</div>
+	<!-- <button></button> -->
+</div>
+
+<div class="group" id="settingsOperator">
+	<div>
+		<sl-select label="Iterative Operator" id="selectIterativeOperator" class="" value="">
+			<sl-menu-item value="projection">Projection Operator<span>No Regularisation</span></sl-menu-item>
+			<sl-menu-item value="identity">Identity Operator</sl-menu-item>
+			<sl-menu-item value="gradient">Gradient Operator</sl-menu-item>
+		</sl-select>
+		<sl-input type="number" label="alpha"></sl-input>
 	</div>
 	<!-- <button></button> -->
 </div>

--- a/webct/blueprints/reconstruction/templates/tab.reconstruction.html.j2
+++ b/webct/blueprints/reconstruction/templates/tab.reconstruction.html.j2
@@ -39,8 +39,8 @@
 				{% include "./tags/cpu.html.j2" %}
 			</sl-menu-item>
 
-			<sl-menu-item value="MLEM" disabled>MLEM
-				<span>Maximum Likelihood Estimation Method</span>
+			<sl-menu-item value="FISTA">FISTA
+				<span> Fast Iterative Shrinkage-Thresholding Algorithm</span>
 				{% include "./tags/cpu.html.j2" %}
 			</sl-menu-item>
 		</sl-select>
@@ -83,7 +83,9 @@
 	<div>
 		<h2>CGLS Settings</h2>
 		<sl-input type="number" label="Iterations" step=1 min=1 value="5" id="inputCGLSIterations"></sl-input>
-		<sl-input type="number" label="Tolerance" step=1 min=1 value="1" id="inputCGLSTolerance" advanced><span slot="suffix">e-6</span></sl-input>
+		<sl-input type="number" label="Tolerance" step=1 min=1 value="1" id="inputCGLSTolerance" advanced>
+			<span slot="suffix">e-6</span>
+		</sl-input>
 	</div>
 	<button></button>
 </div>
@@ -92,6 +94,14 @@
 	<div>
 		<h2>SIRT Settings</h2>
 		<sl-input type="number" id="inputSIRTIterations" label="Iterations" step=1 min=1 value="5"></sl-input>
+	</div>
+	<!-- <button></button> -->
+</div>
+
+<div class="group hidden" id="settingsFISTA">
+	<div>
+		<h2>FISTA Settings</h2>
+		<sl-input type="number" id="inputFISTAIterations" label="Iterations" step=1 min=1 value="5"></sl-input>
 	</div>
 	<!-- <button></button> -->
 </div>
@@ -117,10 +127,13 @@
 			<sl-input type="number" id="inputConLower" label="Lower Constraint" value="0"></sl-input>
 		</div>
 
-		<sl-input id="inputConTVIterations" type="number" label="Iterations" step=1 min=1 value="10" disabled></sl-input>
-		<sl-input type="number" label="Alpha" step=0.01 min=0 value="0.1" id="inputConTVAlpha" advanced disabled></sl-input>
+		<sl-input id="inputConTVIterations" type="number" label="Iterations" step=1 min=1 value="10" disabled>
+		</sl-input>
+		<sl-input type="number" label="Alpha" step=0.01 min=0 value="0.1" id="inputConTVAlpha" advanced disabled>
+		</sl-input>
 		<sl-checkbox id="checkboxConTVIsotropic" checked advanced disabled>Isotropic</sl-checkbox>
-		<sl-input type="number" label="Tolerance" step=1 min=1 value="1" id="inputConTVTolerance" advanced disabled><span slot="suffix">e-6</span></sl-input>
+		<sl-input type="number" label="Tolerance" step=1 min=1 value="1" id="inputConTVTolerance" advanced disabled>
+			<span slot="suffix">e-6</span></sl-input>
 	</div>
 	<button></button>
 </div>
@@ -137,6 +150,17 @@
 			<sl-menu-item value="Neumann">Neumann</sl-menu-item>
 			<sl-menu-item value="Periodic">Periodic</sl-menu-item>
 		</sl-select>
+	</div>
+	<button></button>
+</div>
+
+<div class="group" id="settingsDiff">
+	<div>
+		<sl-select label="Differentiable Function" id="selectDiffOperator" value="least-squares">
+			<sl-menu-item value="least-squares">Least Squares</sl-menu-item>
+		</sl-select>
+		<sl-input type="number" step="0.1" value="1" id="inputDiffLSScaling" label="Scaling Constant" advanced></sl-input>
+		<sl-input type="number" step="0.1" value="1" id="inputDiffLSWeight" label="Weight" advanced></sl-input>
 	</div>
 	<button></button>
 </div>

--- a/webct/blueprints/reconstruction/templates/tab.reconstruction.html.j2
+++ b/webct/blueprints/reconstruction/templates/tab.reconstruction.html.j2
@@ -116,9 +116,9 @@
 	<button></button>
 </div>
 
-<div class="group" id="settingsConstraint">
+<div class="group" id="settingsProximal">
 	<div>
-		<sl-select label="Reconstruction Constraint" id="selectConOperator" class="" value="box">
+		<sl-select label="Reconstruction Proximal" id="selectConOperator" class="" value="box">
 			<sl-menu-item value="box">Indicator Box
 				<span><br>Upper & Lower Bounds</span>
 			</sl-menu-item>
@@ -137,12 +137,12 @@
 
 		<div class="check-property" advanced>
 			<sl-checkbox id="checkboxConUpper"></sl-checkbox>
-			<sl-input type="number" id="inputConUpper" label="Upper Constraint" value="5"></sl-input>
+			<sl-input type="number" id="inputConUpper" label="Upper Proximal" value="5"></sl-input>
 		</div>
 
 		<div class="check-property">
 			<sl-checkbox id="checkboxConLower"></sl-checkbox>
-			<sl-input type="number" id="inputConLower" label="Lower Constraint" value="0"></sl-input>
+			<sl-input type="number" id="inputConLower" label="Lower Proximal" value="0"></sl-input>
 		</div>
 
 		<sl-input id="inputConIterations" type="number" label="Iterations" step=1 min=1 value="10" disabled>

--- a/webct/blueprints/samples/static/scss/models.scss
+++ b/webct/blueprints/samples/static/scss/models.scss
@@ -148,9 +148,6 @@ form.materialForm > sl-divider {
 	grid-column-end: 3;
 }
 
-.hidden {
-	display: none;
-}
 
 div.mixture:not(.hidden) {
 	display: grid;

--- a/webct/components/Reconstruction.py
+++ b/webct/components/Reconstruction.py
@@ -172,7 +172,7 @@ def reconstruct(projections: np.ndarray, capture: CaptureParameters, beam: BeamP
 		sirt = SIRT(ig.allocate(),
 			operator=blockOp,
 			data=data,
-			constraint=params.constraint.get(),
+			constraint=params.constraint.get(ig),
 			max_iteration=params.iterations)
 		sirt.run(verbose=True)
 
@@ -188,7 +188,7 @@ def reconstruct(projections: np.ndarray, capture: CaptureParameters, beam: BeamP
 
 		# Convex function
 		# (Since constraints are most popular, we cheat)
-		convFunction = params.constraint.get()
+		convFunction = params.constraint.get(ig)
 
 		# FISTA
 		# * there is a typing error on parameter g due to a default

--- a/webct/components/Reconstruction.py
+++ b/webct/components/Reconstruction.py
@@ -149,7 +149,6 @@ class SIRTParam(ReconParameters):
 	method: str = "SIRT"
 	iterations: int = 10
 	constraint: Constraint = BoxConstraint()
-	operator: IterativeOperator = ProjectionBlock()
 
 @dataclass(frozen=True)
 class PDHGParam(ReconParameters):
@@ -292,8 +291,10 @@ def reconstruct(projections: np.ndarray, capture: CaptureParameters, beam: BeamP
 		acData.reorder("astra")
 		params = cast(SIRTParam, params)
 
-		# Reconstruction operator
-		blockOp, data = dataWithOp(params.operator, ig, acData)
+		# After a long debugging session, it turns out that SIRT fails when
+		# using block operators, such as IdentityOperator and GradientOperator
+		# for Tikhonov regularisation.
+		blockOp, data = dataWithOp(ProjectionBlock(), ig, acData)
 
 		# Run CGLS Reconstruction
 		sirt = SIRT(ig.allocate(),
@@ -474,11 +475,6 @@ def ReconstructionFromJson(json: dict) -> ReconParameters:
 			tolerance = float(json["tolerance"])
 		return CGLSParam(quality=quality, iterations=iterations, operator=operator, tolerance=tolerance)
 	elif method == "SIRT":
-		# operator
-		operator:IterativeOperator = ProjectionBlock()
-		if "operator" in json:
-			operator = OperatorFromJson(json["operator"])
-
 		iterations:int = 10
 		if "iterations" in json:
 			iterations = int(json["iterations"])
@@ -487,6 +483,6 @@ def ReconstructionFromJson(json: dict) -> ReconParameters:
 		if "constraint" in json:
 			constraint = ConstraintFromJson(json["constraint"])
 
-		return SIRTParam(quality=quality, iterations=iterations, constraint=constraint, operator=operator)
+		return SIRTParam(quality=quality, iterations=iterations, constraint=constraint)
 	else:
 		raise TypeError(f"Recon paramaters for '{method}' is not supported.")

--- a/webct/components/Reconstruction.py
+++ b/webct/components/Reconstruction.py
@@ -13,8 +13,8 @@ from webct.components.Beam import PROJECTION, BeamParameters
 from webct.components.Capture import CaptureParameters
 from webct.components.Detector import DetectorParameters
 from webct.components.recon import (
-	BoxConstraint,
-	Constraint, ConstraintFromJson,
+	BoxProximal,
+	Proximal, ProximalFromJson,
 	IterativeOperator,
 	OperatorFromJson, ProjectionBlock,
 	dataWithOp)
@@ -49,7 +49,7 @@ class CGLSParam(ReconParameters):
 class SIRTParam(ReconParameters):
 	method: str = "SIRT"
 	iterations: int = 10
-	constraint: Constraint = BoxConstraint()
+	constraint: Proximal = BoxProximal()
 	operator: IterativeOperator = ProjectionBlock()
 
 @dataclass(frozen=True)
@@ -57,7 +57,7 @@ class FISTAParam(ReconParameters):
 	method: str = "FISTA"
 	iterations: int = 10
 	diff: Diff = DiffLeastSquares()
-	constraint: Constraint = BoxConstraint()
+	constraint: Proximal = BoxProximal()
 
 
 # @dataclass(frozen=True)
@@ -292,15 +292,15 @@ def ReconstructionFromJson(json: dict) -> ReconParameters:
 		if "iterations" in json:
 			iterations = int(json["iterations"])
 
-		constraint = BoxConstraint()
+		constraint = BoxProximal()
 		if "constraint" in json:
-			constraint = ConstraintFromJson(json["constraint"])
+			constraint = ProximalFromJson(json["constraint"])
 
 		return SIRTParam(quality=quality, iterations=iterations, constraint=constraint, operator=operator)
 	elif method == "FISTA":
-		constraint:Constraint = BoxConstraint()
+		constraint:Proximal = BoxProximal()
 		if "constraint" in json:
-			constraint = ConstraintFromJson(json["constraint"])
+			constraint = ProximalFromJson(json["constraint"])
 
 		iterations = 10
 		if "iterations" in json:

--- a/webct/components/recon/Constraints.py
+++ b/webct/components/recon/Constraints.py
@@ -1,18 +1,22 @@
 from dataclasses import dataclass
 from typing import Dict, Type, Union, cast
+from cil.framework import ImageGeometry
 from cil.optimisation.functions import (IndicatorBox, TotalVariation, Function)
+from cil.plugins.ccpi_regularisation.functions import (FGP_TV, TGV, TNV)
 import numpy as np
 
 @dataclass(frozen=True)
 class Constraint():
 	method:str
 
-	def get(self) -> Function:
+	def get(self, ig:ImageGeometry) -> Function:
 		...
 
 @dataclass(frozen=True)
 class ConstraintParams():
 	...
+
+# ------------------------
 
 @dataclass(frozen=True)
 class BoxConstraintParams(ConstraintParams):
@@ -24,8 +28,10 @@ class BoxConstraint(Constraint):
 	method:str = "box"
 	params:BoxConstraintParams = BoxConstraintParams()
 
-	def get(self) -> Function:
+	def get(self, ig:ImageGeometry) -> Function:
 		return IndicatorBox(self.params.lower, self.params.upper)
+
+# ------------------------
 
 @dataclass(frozen=True)
 class TVConstraintParams(ConstraintParams):
@@ -41,12 +47,60 @@ class TVConstraint(Constraint):
 	method:str = "tv"
 	params:TVConstraintParams = TVConstraintParams()
 
-	def get(self) -> Function:
+	def get(self, ig:ImageGeometry) -> Function:
 		return self.params.alpha * TotalVariation(self.params.iterations,
 			self.params.tolerance / 1000000,
 			upper=self.params.upper,
 			lower=self.params.lower,
 			isotropic=self.params.isotropic)
+
+# ------------------------
+
+@dataclass(frozen=True)
+class FGPTVConstraintParams(ConstraintParams):
+	iterations: int = 100
+	alpha: float = 1
+	tolerance: float = 1
+	isotropic: bool = True
+	nonnegativity: bool = True
+
+@dataclass(frozen=True)
+class FGPTVConstraint(Constraint):
+	method:str = "fgp-tv"
+	params:FGPTVConstraintParams = FGPTVConstraintParams()
+
+	def get(self, ig:ImageGeometry) -> Function:
+		# The FGP_TV regularisation does not incorporate information on the
+		# ImageGeometry, i.e., pixel/voxel size.
+		# https://tomographicimaging.github.io/CIL/nightly/plugins.html#total-variation
+		return (self.params.alpha / ig.voxel_size_x) * FGP_TV(max_iteration=self.params.iterations,
+			tolerance=self.params.tolerance / 1000000,
+			isotropic=self.params.isotropic,
+			nonnegativity=self.params.nonnegativity,
+			device="gpu")
+
+# ------------------------
+
+@dataclass(frozen=True)
+class TGVConstraintParams(ConstraintParams):
+	iterations: int = 100
+	alpha: float = 0.1
+	tolerance: float = 1
+	gamma: float = 1
+
+@dataclass(frozen=True)
+class TGVConstraint(Constraint):
+	method:str = "tgv"
+	params:TGVConstraintParams = TGVConstraintParams()
+
+	def get(self, ig:ImageGeometry) -> Function:
+		return TGV(alpha=self.params.alpha,
+			gamma=self.params.gamma,
+			max_iteration=self.params.iterations,
+			tolerance=self.params.tolerance / 1000000,
+			device="cpu")
+
+# ------------------------
 
 Constraints:Dict[str, Dict[str, Union[Type[Constraint], Type[ConstraintParams]]]] = {
 	"box": {
@@ -56,7 +110,15 @@ Constraints:Dict[str, Dict[str, Union[Type[Constraint], Type[ConstraintParams]]]
 	"tv": {
 		"type": TVConstraint,
 		"params": TVConstraintParams
-	}
+	},
+	"fgp-tv": {
+		"type": FGPTVConstraint,
+		"params": FGPTVConstraintParams
+	},
+	"tgv": {
+		"type": TGVConstraint,
+		"params": TGVConstraintParams
+	},
 }
 
 def ConstraintFromJson(json:dict) -> Constraint:
@@ -108,7 +170,65 @@ def ConstraintFromJson(json:dict) -> Constraint:
 		if "isotropic" in conParams:
 			isotropic = bool(conParams["isotropic"])
 
-		tvparams = TVConstraintParams(iterations, alpha, tolerance, upper, lower, isotropic)
+		tvparams = TVConstraintParams(
+			iterations=iterations,
+			alpha=alpha,
+			tolerance=tolerance,
+			upper=upper,
+			lower=lower,
+			isotropic=isotropic)
+
 		return TVConstraint(params=tvparams)
+
+	elif conType == FGPTVConstraint:
+		iterations = 100
+		alpha = 1
+		tolerance = 1
+		isotropic = True
+		nonnegativity = True
+
+		if "alpha" in conParams:
+			alpha = float(conParams["alpha"])
+		if "iterations" in conParams:
+			iterations = int(conParams["iterations"])
+		if "tolerance" in conParams:
+			tolerance = float(conParams["tolerance"])
+		if "isotropic" in conParams:
+			isotropic = bool(conParams["isotropic"])
+		if "nonnegativity" in conParams:
+			nonnegativity = bool(conParams["nonnegativity"])
+
+		fgptvparams = FGPTVConstraintParams(
+			iterations=iterations,
+			alpha=alpha,
+			tolerance=tolerance,
+			isotropic=isotropic,
+			nonnegativity=nonnegativity)
+
+		return FGPTVConstraint(params=fgptvparams)
+
+	elif conType == TGVConstraint:
+		iterations = 100
+		alpha = 1
+		gamma = 1
+		tolerance = 1
+
+		if "alpha" in conParams:
+			alpha = float(conParams["alpha"])
+		if "gamma" in conParams:
+			gamma = float(conParams["gamma"])
+		if "iterations" in conParams:
+			iterations = int(conParams["iterations"])
+		if "tolerance" in conParams:
+			tolerance = float(conParams["tolerance"])
+
+		tgvparams = TGVConstraintParams(
+			iterations=iterations,
+			alpha=alpha,
+			gamma=gamma,
+			tolerance=tolerance)
+
+		return TGVConstraint(params=tgvparams)
+
 	else:
 		raise NotImplementedError(f"Constraint method '{conType}' is not implemented.")

--- a/webct/components/recon/Constraints.py
+++ b/webct/components/recon/Constraints.py
@@ -1,0 +1,114 @@
+from dataclasses import dataclass
+from typing import Dict, Type, Union, cast
+from cil.optimisation.functions import (IndicatorBox, TotalVariation, Function)
+import numpy as np
+
+@dataclass(frozen=True)
+class Constraint():
+	method:str
+
+	def get(self) -> Function:
+		...
+
+@dataclass(frozen=True)
+class ConstraintParams():
+	...
+
+@dataclass(frozen=True)
+class BoxConstraintParams(ConstraintParams):
+	upper: float = np.inf
+	lower: float = -np.inf
+
+@dataclass(frozen=True)
+class BoxConstraint(Constraint):
+	method:str = "box"
+	params:BoxConstraintParams = BoxConstraintParams()
+
+	def get(self) -> Function:
+		return IndicatorBox(self.params.lower, self.params.upper)
+
+@dataclass(frozen=True)
+class TVConstraintParams(ConstraintParams):
+	iterations: int = 100
+	alpha: float = 0.1
+	tolerance: float = 1
+	upper: float = np.inf
+	lower: float = -np.inf
+	isotropic: bool = True
+
+@dataclass(frozen=True)
+class TVConstraint(Constraint):
+	method:str = "tv"
+	params:TVConstraintParams = TVConstraintParams()
+
+	def get(self) -> Function:
+		return self.params.alpha * TotalVariation(self.params.iterations,
+			self.params.tolerance / 1000000,
+			upper=self.params.upper,
+			lower=self.params.lower,
+			isotropic=self.params.isotropic)
+
+Constraints:Dict[str, Dict[str, Union[Type[Constraint], Type[ConstraintParams]]]] = {
+	"box": {
+		"type": BoxConstraint,
+		"params":BoxConstraintParams
+	},
+	"tv": {
+		"type": TVConstraint,
+		"params": TVConstraintParams
+	}
+}
+
+def ConstraintFromJson(json:dict) -> Constraint:
+	if "method" not in json:
+		raise KeyError("Constraint key lacks a method key.")
+	if "params" not in json:
+		raise KeyError("Constraint key lacks a param key.")
+
+	if json["method"] not in Constraints:
+		raise NotImplementedError(f"Constraint '{json['method']}' is not supported.")
+
+	conType:Type[Constraint] = cast(Type[Constraint], Constraints[json["method"]]["type"])
+	conParams = json["params"]
+
+	if conType == BoxConstraint:
+		upper = np.inf
+		lower = -np.inf
+		# Check to see if bound values exist and are not none. Json does not
+		# support negative infinities, and they are therefore represented as
+		# null.
+		if "upper" in conParams:
+			if conParams["upper"] is not None:
+				upper = float(conParams["upper"])
+		if "lower" in conParams:
+			if conParams["lower"] is not None:
+				lower = float(conParams["lower"])
+		return BoxConstraint(params=BoxConstraintParams(upper, lower))
+
+	elif conType == TVConstraint:
+		alpha = 0.1
+		iterations = 100
+		tolerance = 1
+		upper = np.inf
+		lower = -np.inf
+		isotropic = True
+
+		if "alpha" in conParams:
+			alpha = float(conParams["alpha"])
+		if "iterations" in conParams:
+			iterations = int(conParams["iterations"])
+		if "tolerance" in conParams:
+			tolerance = float(conParams["tolerance"])
+		if "upper" in conParams:
+			if conParams["upper"] is not None:
+				upper = float(conParams["upper"])
+		if "lower" in conParams:
+			if conParams["lower"] is not None:
+				lower = float(conParams["lower"])
+		if "isotropic" in conParams:
+			isotropic = bool(conParams["isotropic"])
+
+		tvparams = TVConstraintParams(iterations, alpha, tolerance, upper, lower, isotropic)
+		return TVConstraint(params=tvparams)
+	else:
+		raise NotImplementedError(f"Constraint method '{conType}' is not implemented.")

--- a/webct/components/recon/Differentiable.py
+++ b/webct/components/recon/Differentiable.py
@@ -1,0 +1,67 @@
+from dataclasses import dataclass
+from typing import Dict, Type, Union, cast
+from cil.framework import AcquisitionData, ImageGeometry
+from cil.plugins.astra import ProjectionOperator
+from cil.optimisation.functions import (IndicatorBox, TotalVariation, Function, LeastSquares)
+import numpy as np
+
+@dataclass(frozen=True)
+class DiffParams():
+	...
+
+@dataclass(frozen=True)
+class Diff():
+	method: str
+	params: DiffParams
+
+	def get(self, ig:ImageGeometry, data:AcquisitionData) -> Function:
+		...
+
+@dataclass(frozen=True)
+class DiffLeastSquaresParams(DiffParams):
+	scaling_constant: float = 1
+	weight: float = 1
+
+@dataclass(frozen=True)
+class DiffLeastSquares(Diff):
+	method: str = "projection"
+	params: DiffLeastSquaresParams = DiffLeastSquaresParams()
+
+	def get(self, ig:ImageGeometry, data:AcquisitionData) -> Function:
+		opProj = ProjectionOperator(ig, data)
+		return LeastSquares(opProj, data, c=self.params.scaling_constant, weight=self.params.weight)
+
+
+Diffs:Dict[str, Dict[str, Union[Type[Diff], Type[DiffParams]]]] = {
+	"leastsquares": {
+		"type": DiffLeastSquares,
+		"params": DiffLeastSquaresParams
+	}
+}
+
+def DiffFromJson(json:dict) -> Diff:
+	if "method" not in json:
+		raise KeyError("Diff key lacks a method key.")
+	if "params" not in json:
+		raise KeyError("Diff key lacks a param key.")
+
+	if json["method"] not in Diff:
+		raise NotImplementedError(f"Diff '{json['method']}' is not supported.")
+
+	diffType:Type[Diff] = cast(Type[Diff], Diffs[json["method"]]["type"])
+	diffParams = json["params"]
+
+	if diffType == DiffLeastSquares:
+		scaling_constant = 1
+		if "scaling_constant" in diffParams:
+			scaling_constant = diffParams["scaling_constant"]
+		weight = 1
+		if "weight" in diffParams:
+			weight = diffParams["weight"]
+		diffLSParams = DiffLeastSquaresParams(scaling_constant, weight)
+		return DiffLeastSquares(params=diffLSParams)
+
+	# elif conType == TVDiff:
+	# 	...
+	else:
+		raise NotImplementedError(f"Diff method '{diffType}' is not implemented.")

--- a/webct/components/recon/Differentiable.py
+++ b/webct/components/recon/Differentiable.py
@@ -20,7 +20,6 @@ class Diff():
 @dataclass(frozen=True)
 class DiffLeastSquaresParams(DiffParams):
 	scaling_constant: float = 1
-	weight: float = 1
 
 @dataclass(frozen=True)
 class DiffLeastSquares(Diff):
@@ -29,9 +28,8 @@ class DiffLeastSquares(Diff):
 
 	def get(self, ig:ImageGeometry, data:AcquisitionData) -> Function:
 		opProj = ProjectionOperator(ig, data.geometry)
-
-		# For now, float weights are unsupported by LeastSquares
-		# return LeastSquares(opProj, data, c=self.params.scaling_constant, weight=self.params.weight)
+		# Weight parameter only works with DataContainers
+		# https://github.com/TomographicImaging/CIL/issues/1334
 		return LeastSquares(opProj, data, c=self.params.scaling_constant)
 
 
@@ -58,10 +56,7 @@ def DiffFromJson(json:dict) -> Diff:
 		scaling_constant = 1
 		if "scaling_constant" in diffParams:
 			scaling_constant = diffParams["scaling_constant"]
-		weight = 1
-		if "weight" in diffParams:
-			weight = diffParams["weight"]
-		diffLSParams = DiffLeastSquaresParams(scaling_constant, weight)
+		diffLSParams = DiffLeastSquaresParams(scaling_constant)
 		return DiffLeastSquares(params=diffLSParams)
 
 	# elif conType == TVDiff:

--- a/webct/components/recon/IterativeOperators.py
+++ b/webct/components/recon/IterativeOperators.py
@@ -1,0 +1,135 @@
+from dataclasses import dataclass
+from typing import Dict, Literal, Tuple, Type, Union, cast
+
+from cil.framework import AcquisitionData, ImageGeometry, BlockDataContainer
+from cil.optimisation.operators import (Operator, IdentityOperator, BlockOperator, GradientOperator)
+from cil.plugins.astra.operators import ProjectionOperator
+
+class IterativeBlockParams():
+	...
+
+@dataclass(frozen=True)
+class IterativeOperator:
+	method:str
+	params:IterativeBlockParams
+
+	def get(self, ig:ImageGeometry, acData:AcquisitionData) -> Tuple[BlockOperator, Operator]:
+		...
+
+@dataclass(frozen=True)
+class ProjectionBlockParams(IterativeBlockParams):
+	...
+
+@dataclass(frozen=True)
+class ProjectionBlock(IterativeOperator):
+	method:str = "projection"
+	params:ProjectionBlockParams = ProjectionBlockParams()
+
+	def get(self, ig:ImageGeometry, acData:AcquisitionData) -> Tuple[Operator, None]:
+		opProj = ProjectionOperator(ig,acData.geometry)
+		# Wrapping a ProjectionOperator in a block operator causes an invalid reconstruction output
+		# opblock_proj = BlockOperator(opProj)
+
+		return opProj, None
+
+@dataclass(frozen=True)
+class IdentityBlockParams(IterativeBlockParams):
+	alpha:float=0.1
+
+@dataclass(frozen=True)
+class IdentityBlock(IterativeOperator):
+	method:str = "identity"
+	params:IdentityBlockParams = IdentityBlockParams()
+
+	def get(self, ig:ImageGeometry, acData:AcquisitionData) -> Tuple[BlockOperator, Operator]:
+		opProj = ProjectionOperator(ig,acData.geometry)
+		opIdent = IdentityOperator(ig)
+
+		opblock_ident = BlockOperator(opProj, self.params.alpha * opIdent)
+		return opblock_ident, opIdent
+
+@dataclass(frozen=True)
+class GradientBlockParams(IterativeBlockParams):
+	alpha:float = 0.1
+	boundary:Union[Literal["Neumann"], Literal["Periodic"]] = "Neumann"
+
+@dataclass(frozen=True)
+class GradientBlock(IterativeOperator):
+	method:str = "gradient"
+	params:GradientBlockParams = GradientBlockParams()
+
+	def get(self, ig:ImageGeometry, acData:AcquisitionData) -> Tuple[BlockOperator, Operator]:
+		opProj = ProjectionOperator(ig, acData.geometry)
+		opGrad = GradientOperator(ig, bnd_cond=self.params.boundary)
+
+		opblock_grad = BlockOperator(opProj, self.params.alpha * opGrad)
+		return opblock_grad, opGrad
+
+IterativeOperators:Dict[str, Dict[str, Union[Type[IterativeOperator], Type[IterativeBlockParams]]]] = {
+	"projection": {
+		"type": ProjectionBlock,
+		"params":ProjectionBlockParams
+	},
+	"identity": {
+		"type": IdentityBlock,
+		"params":IdentityBlockParams
+	},
+	"gradient": {
+		"type": GradientBlock,
+		"params":GradientBlockParams
+	}
+}
+
+def dataWithOp(operator:IterativeOperator, ig:ImageGeometry, acData:AcquisitionData) -> Tuple[Union[BlockOperator,ProjectionOperator], Union[AcquisitionData, BlockDataContainer]]:
+		# Note: A projection operator will return (Operator, None)
+		blockOp, Lop = operator.get(ig, acData)
+
+		# Need to allocate data into a BlockDataContainer when using
+		# block operations. The projection block operator is just a
+		# wrapped ProjectionOperator, and does not work on
+		# BlockDataContainer.
+		data = acData
+		if operator.method != "projection":
+			if Lop.range is not None:
+				data = BlockDataContainer(acData, Lop.range.allocate(0))
+			else:
+				raise ValueError(f"Unexpected None range of block projection operator '{operator.method}'")
+		return blockOp, data
+
+def OperatorFromJson(json: dict) -> IterativeOperator:
+	if "method" not in json:
+		raise KeyError("Operator key lacks a method key.")
+	if "params" not in json:
+		raise KeyError("Operator key lacks a param key.")
+
+	if json["method"] not in IterativeOperators:
+		raise NotImplementedError(f"Iterative operator '{json['method']}' is not supported.")
+
+	opType:Type[IterativeOperator] = cast(Type[IterativeOperator], IterativeOperators[json["method"]]["type"])
+	opParams = json["params"]
+
+	if opType == ProjectionBlock:
+		return ProjectionBlock()
+
+	elif opType == IdentityBlock:
+		alpha = 0.1
+		if "alpha" in opParams:
+			alpha = float(opParams["alpha"])
+		operatorParams = IdentityBlockParams(alpha)
+		return IdentityBlock(params=operatorParams)
+
+	elif opType == GradientBlock:
+		alpha = 0.1
+		if "alpha" in opParams:
+			alpha = float(opParams["alpha"])
+		boundary = "Neumann"
+
+		if "boundary" in opParams:
+			if opParams["boundary"].lower() == "periodic":
+				boundary = "Periodic"
+
+		operatorParams = GradientBlockParams(alpha, boundary)
+		return GradientBlock(params=operatorParams)
+
+	else:
+		raise NotImplementedError(f"Iterative operator {opType} is not implemented.")

--- a/webct/components/recon/IterativeOperators.py
+++ b/webct/components/recon/IterativeOperators.py
@@ -26,7 +26,7 @@ class ProjectionBlock(IterativeOperator):
 	params:ProjectionBlockParams = ProjectionBlockParams()
 
 	def get(self, ig:ImageGeometry, acData:AcquisitionData) -> Tuple[Operator, None]:
-		opProj = ProjectionOperator(ig,acData.geometry)
+		opProj = ProjectionOperator(ig, acData.geometry)
 		# Wrapping a ProjectionOperator in a block operator causes an invalid reconstruction output
 		# opblock_proj = BlockOperator(opProj)
 

--- a/webct/components/recon/__init__.py
+++ b/webct/components/recon/__init__.py
@@ -1,12 +1,12 @@
-from .Constraints import (
-	Constraint,
-	ConstraintParams,
-	BoxConstraint,
-	BoxConstraintParams,
-	TVConstraint,
-	TVConstraintParams,
-	Constraints,
-	ConstraintFromJson,
+from .Proximals import (
+	Proximal,
+	ProximalParams,
+	BoxProximal,
+	BoxProximalParams,
+	TVProximal,
+	TVProximalParams,
+	Proximals,
+	ProximalFromJson,
 )
 from .IterativeOperators import (
 	IterativeOperator,

--- a/webct/components/recon/__init__.py
+++ b/webct/components/recon/__init__.py
@@ -1,0 +1,23 @@
+from .Constraints import (
+	Constraint,
+	ConstraintParams,
+	BoxConstraint,
+	BoxConstraintParams,
+	TVConstraint,
+	TVConstraintParams,
+	Constraints,
+	ConstraintFromJson,
+)
+from .IterativeOperators import (
+	IterativeOperator,
+	IterativeBlockParams,
+	ProjectionBlock,
+	ProjectionBlockParams,
+	IdentityBlock,
+	IdentityBlockParams,
+	GradientBlock,
+	GradientBlockParams,
+	IterativeOperators,
+	OperatorFromJson,
+	dataWithOp,
+)

--- a/webct/components/recon/__init__.py
+++ b/webct/components/recon/__init__.py
@@ -21,3 +21,11 @@ from .IterativeOperators import (
 	OperatorFromJson,
 	dataWithOp,
 )
+from .Differentiable import (
+	Diff,
+	DiffParams,
+	DiffLeastSquares,
+	DiffLeastSquaresParams,
+	Diffs,
+	DiffFromJson,
+)


### PR DESCRIPTION
Implement iterative reconstruction methods available in [CIL](https://github.com/TomographicImaging/CIL).
Also allow for selecting arbitrary regularisation methods present in [CCPi-Regularisation-Toolkit](https://github.com/vais-ral/CCPi-Regularisation-Toolkit) for iterative methods.

- ~~[GD](https://tomographicimaging.github.io/CIL/nightly/optimisation.html#gd)~~
- [x] [CGLS](https://tomographicimaging.github.io/CIL/nightly/optimisation.html#cgls)
- [x] [SIRT](https://tomographicimaging.github.io/CIL/nightly/optimisation.html#sirt)
-  [~~ISTA~~](https://tomographicimaging.github.io/CIL/nightly/optimisation.html#ista) Use FISTA instead
- [x] [FISTA](https://tomographicimaging.github.io/CIL/nightly/optimisation.html#fista)
- [~~PDHG~~](https://tomographicimaging.github.io/CIL/nightly/optimisation.html#pdhg) Not implemented, take a look at #37
- [~~LADMM~~](https://tomographicimaging.github.io/CIL/nightly/optimisation.html#ladmm) Not implemented, take a look at #37
- [~~SPDHG~~](https://tomographicimaging.github.io/CIL/nightly/optimisation.html#spdhg) Not implemented, take a look at #37
- [Tikhoniv Block Framework](https://tomographicimaging.github.io/CIL/nightly/optimisation.html#block-framework)
    - [x] Projection Operator
    - [x] [Identity Operator](https://tomographicimaging.github.io/CIL/nightly/optimisation.html#cil.optimisation.operators.IdentityOperator)
    - [x] [Gradient Operator](https://tomographicimaging.github.io/CIL/nightly/optimisation.html#gradientoperator)
- [Constraint Functions](https://tomographicimaging.github.io/CIL/nightly/optimisation.html#functions) 
    - [x] [IndicatorBox](https://tomographicimaging.github.io/CIL/nightly/optimisation.html#gradientoperator)
    - [x] [Total Variation](https://tomographicimaging.github.io/CIL/nightly/optimisation.html#gradientoperator)
    - [x] [ccpi-reg] [Fast Gradient Projection Total Variation (FGP_TV)](https://tomographicimaging.github.io/CIL/nightly/plugins.html#cil.plugins.ccpi_regularisation.functions.FGP_TV)
    - [x] [ccpi-reg] [Total Generalised Variation (TGV)](https://tomographicimaging.github.io/CIL/nightly/plugins.html#cil.plugins.ccpi_regularisation.functions.TGV)
    - [ccpi-reg] ~~[Fast Gradient Projection Discrete Total Variation (FGP_dTV)](https://tomographicimaging.github.io/CIL/nightly/plugins.html#cil.plugins.ccpi_regularisation.functions.FGP_dTV)~~ Requires a reference image, use FGP_TV
    - [ccpi-reg] ~~[Total Nuclear Variation (TNV)](https://tomographicimaging.github.io/CIL/nightly/plugins.html#cil.plugins.ccpi_regularisation.functions.TNV)~~ 2D only

Bugs:
- [x] Errors when combining block frameworks and constraint functions
    - Error was actually due to using GradientOperator with SIRT
 - [x] ~~Error when using a float weight for LeastSquares~~
     - ~~Has been reported to CIL and confirmed as a bug~~
     - Not a bug, `c` is the float weight paramater, `weight` is the paramater for DataContainers