### PR TITLE
feat: :sparkles: Use gvxr from pip (#29)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,12 +6,9 @@ channels:
   - intel
   - astra-toolbox
 dependencies:
-  - cmake # Needed only for docker
-
   # Runtime
   - python>=3.9
   - flask
-  # - gvirtualxray # Installed by docker container
   - scipy
   - matplotlib<3.5
   - opencv
@@ -26,6 +23,7 @@ dependencies:
   - pip
   - pip:
     # Runtime
+    - gvxr
     - imageio[ffmpeg]
     - git+https://bitbucket.org/spekpy/spekpy_release.git
     - xpecgen

--- a/webct/components/Material.py
+++ b/webct/components/Material.py
@@ -2,8 +2,7 @@ from dataclasses import dataclass
 from enum import Enum
 import json
 from typing import Dict, Iterator, Tuple
-from gvxrPython3.gvxrPython3 import getElementAtomicNumber
-
+from gvxrPython3 import gvxr
 
 @dataclass(frozen=True)
 class SaveableParameters:
@@ -127,7 +126,7 @@ class ElementMaterial(Material):
 		Returns:
 			int: The atomic number of the element.
 		"""
-		return getElementAtomicNumber(self.element)
+		return gvxr.getElementAtomicNumber(self.element)
 
 
 @dataclass(frozen=True)
@@ -223,7 +222,7 @@ class MixtureMaterial(Material):
 	def atomicNumbers(self) -> Tuple[int, ...]:
 		atomics = []
 		for element in self.elements:
-			atomics.append(getElementAtomicNumber(element))
+			atomics.append(gvxr.getElementAtomicNumber(element))
 		return tuple(atomics)
 
 	def __iter__(self) -> Iterator[str]:

--- a/webct/components/sim/simulators/GVXRSimulator.py
+++ b/webct/components/sim/simulators/GVXRSimulator.py
@@ -1,5 +1,5 @@
 from typing import List, Tuple
-import gvxrPython3.gvxrPython3 as gvxr
+from gvxrPython3 import gvxr
 import numpy as np
 
 from webct.components.Beam import PROJECTION, Beam


### PR DESCRIPTION
gVirtualXRay is now on pypi! :tada: Celebrate by using the new pip package rather than requiring a local build.
Closes #29