### PR TITLE
feat: :sparkles: Add support for focal spot size (#5)

### DIFF
--- a/webct/blueprints/beam/static/js/beam.ts
+++ b/webct/blueprints/beam/static/js/beam.ts
@@ -11,7 +11,7 @@ import { AlgElement } from "../../../reconstruction/static/js/recon";
 import { BeamResponseRegistry, processResponse, requestBeamData, sendBeamData } from "./api";
 import { BeamConfigError, BeamRequestError, showError } from "./errors";
 import { BeamGenerator, BeamProperties, Filter, LabBeam, MedBeam, SourceType, SpectraDisplay, SynchBeam, ViewFormat } from "./types";
-import { validateFilter } from "./validation";
+import { validateFilter, validateSpotSize } from "./validation";
 
 // ====================================================== //
 // ================== Document Elements ================= //
@@ -26,7 +26,7 @@ let BeamIntensityElement:SlInput;
 let BeamMASElement:SlInput;
 let BeamAngleElement:SlInput;
 let BeamHarmonicsElement:SlCheckbox;
-let BeamSpotSize:SlInput;
+let BeamSpotSizeElement:SlInput;
 
 let BeamMaterialElement:SlInput;
 
@@ -138,7 +138,7 @@ export function setupBeam(): boolean {
 	BeamIntensityElement = intensity_element as SlInput;
 	BeamMASElement = mas_element as SlInput;
 	BeamAngleElement = angle_element as SlInput;
-	BeamSpotSize = spot_size as SlInput;
+	BeamSpotSizeElement = spot_size as SlInput;
 	BeamMaterialElement = beam_material_element as SlInput;
 	BeamHarmonicsElement = harmonics_element as SlCheckbox;
 
@@ -203,6 +203,12 @@ export function setupBeam(): boolean {
 		validateFilter(FilterSizeElement);
 	});
 
+	BeamSpotSizeElement.addEventListener("sl-input", () => {
+		validateSpotSize(BeamSpotSizeElement)
+	})
+	BeamSpotSizeElement.addEventListener("sl-change", () => {
+		validateSpotSize(BeamSpotSizeElement)
+	})
 
 	SpectraCanvas = spectra_canvas as HTMLCanvasElement;
 
@@ -348,7 +354,7 @@ export function getBeamParms():BeamProperties {
 			parseFloat(BeamVoltageElement.value as string),
 			parseFloat(BeamExposureElement.value as string),
 			parseFloat(BeamIntensityElement.value as string),
-			parseFloat(BeamSpotSize.value as string),
+			parseFloat(BeamSpotSizeElement.value as string),
 			parseInt(BeamMaterialElement.value as string),
 			BeamGeneratorElement.value as BeamGenerator,
 			parseFloat(BeamAngleElement.value as string),
@@ -364,7 +370,7 @@ export function getBeamParms():BeamProperties {
 		beam = new MedBeam(
 			parseFloat(BeamVoltageElement.value as string),
 			parseFloat(BeamMASElement.value as string),
-			parseFloat(BeamSpotSize.value as string),
+			parseFloat(BeamSpotSizeElement.value as string),
 			parseInt(BeamMaterialElement.value as string),
 			BeamGeneratorElement.value as BeamGenerator,
 			parseFloat(BeamAngleElement.value as string),
@@ -407,7 +413,7 @@ export function setBeamParams(beam:BeamProperties) {
 		BeamAngleElement.value = params.anodeAngle+"";
 		BeamGeneratorElement.value = params.generator;
 		BeamMaterialElement.value = params.material+"";
-		BeamSpotSize.value = params.spotSize+"";
+		BeamSpotSizeElement.value = params.spotSize+"";
 		break;
 	case "med":
 		params = beam as MedBeam;
@@ -416,7 +422,7 @@ export function setBeamParams(beam:BeamProperties) {
 		BeamGeneratorElement.value = params.generator;
 		BeamAngleElement.value = params.anodeAngle+"";
 		BeamMaterialElement.value = params.material+"";
-		BeamSpotSize.value = params.spotSize+"";
+		BeamSpotSizeElement.value = params.spotSize+"";
 		BeamVoltageElement.value = params.voltage+"";
 		break;
 	case "synch":

--- a/webct/blueprints/beam/static/js/validation.ts
+++ b/webct/blueprints/beam/static/js/validation.ts
@@ -60,6 +60,16 @@ const FilterValidator: Validator = {
 };
 
 /**
+ * Spot Size validator.
+ */
+const SpotSizeValidator: Validator = {
+	min: 0,
+	max: 10000,
+	type: "number",
+	message: "Focal Spot Size cannot be negative."
+};
+
+/**
  * Validate Voltage input of X-Ray Tube.
  * @param VoltageElement - Tube Voltage Input to validate.
  * @param material - Material of X-Ray Tube.
@@ -91,4 +101,13 @@ export function validateAngle(AngleElement: SlInput): boolean {
  */
 export function validateFilter(FilterElement: SlInput): boolean {
 	return validateInput(FilterElement, FilterValidator);
+}
+
+/**
+ * Validate Spot Size Thickness text input.
+ * @param SpotSizeElement - Spot Size Thickness input to validate.
+ * @returns True if input is valid, false otherwise. Side effect: Passed element will have help-text displaying the validation failure reason.
+ */
+export function validateSpotSize(SpotSizeElement: SlInput): boolean {
+	return validateInput(SpotSizeElement, SpotSizeValidator);
 }

--- a/webct/blueprints/beam/templates/tab.beam.html.j2
+++ b/webct/blueprints/beam/templates/tab.beam.html.j2
@@ -52,11 +52,9 @@
 			<sl-menu-item value="42">Mo (Molydbenum)</sl-menu-item>
 			<sl-menu-item value="45">Rh (Rhodium)</sl-menu-item>
 		</sl-select>
-		<sl-tooltip content="Planned feature" placement="bottom">
-			<sl-input type="number" label="Focal Spot Size" step="0.01" value="0.0" id="inputBeamSpotSize" disabled >
-				{% include "./units/size.html.j2" %}
-			</sl-input>
-		</sl-tooltip>
+		<sl-input type="number" label="Focal Spot Size" step="0.01" value="0.0" id="inputBeamSpotSize">
+			{% include "./units/size.html.j2" %}
+		</sl-input>
 		<sl-input label="Anode Angle" type="number" step="0.1" value="12" id="inputBeamAngle" advanced >
 			{% include "./units/degree.html.j2" %}
 		</sl-input>

--- a/webct/components/Beam.py
+++ b/webct/components/Beam.py
@@ -66,6 +66,7 @@ class BeamParameters:
 	method: str
 	filters: Tuple[Filter, ...]
 	projection: PROJECTION
+	spotSize:float
 
 
 	def to_json(self) -> dict:
@@ -76,8 +77,9 @@ class BeamParameters:
 		method = str(json["method"])
 		filters = parseFilters(json["filters"])
 		projection = PROJECTION(json["projection"])
+		spotSize = float(json["spotSize"])
 
-		return BeamParameters(method, filters, projection)
+		return BeamParameters(method, filters, projection, spotSize)
 
 	def getSpectra(self) -> Tuple[Spectra, Spectra]:
 		raise NotImplementedError("Cannot create a beam spectra from BeamParamaters.")
@@ -85,7 +87,6 @@ class BeamParameters:
 @dataclass(frozen=True)
 class TubeBeam():
 	voltage: float
-	spotSize: float
 	anodeAngle: float
 	generator: BEAM_GENERATOR
 	material: Element
@@ -196,7 +197,8 @@ class SynchBeam(BeamParameters):
 		energy=energy,
 		exposure=exposure,
 		intensity=intensity,
-		harmonics=harmonics)
+		harmonics=harmonics,
+		spotSize=0)
 
 	def getSpectra(self) -> Tuple[Spectra, Spectra]:
 		return generateSpectra(self)

--- a/webct/components/sim/clients/SimClient.py
+++ b/webct/components/sim/clients/SimClient.py
@@ -6,7 +6,7 @@ import sys
 from dataclasses import dataclass
 from enum import Enum
 from multiprocessing import Pipe, Process, shared_memory
-from multiprocessing.connection import PipeConnection
+from multiprocessing.connection import Connection
 from random import Random
 from typing import Any, Tuple
 
@@ -114,8 +114,8 @@ class SimClient(Process):
 	capture: CaptureParameters
 
 	# ''Shared'' variables
-	conn_parent: PipeConnection
-	conn_child: PipeConnection
+	conn_parent: Connection
+	conn_child: Connection
 
 	# process variables
 	_simulator: GVXRSimulator


### PR DESCRIPTION
- Add support for focal spot in beam parameters
- Change typing of PipeConnection to Connection
   - This fixes a compilation issue on Linux
- Replace gvxr.computeProjectionSet() with a loop
   - This is due to a breaking change with latest master of gvxr
- Add tqdm progress bar to reconstruction
   - This may be temporary, should be investigated with Better Error System #52