### PR TITLE
fix: :bug: Fix PermissionError when downloading files on Linux (#63)

### DIFF
--- a/webct/blueprints/preview/routes.py
+++ b/webct/blueprints/preview/routes.py
@@ -102,7 +102,8 @@ def getDownload():
 	sim = Sim(session)
 
 	if sim.download.status == DownloadStatus.DONE:
-		sim.download.location(resource).absolute().chmod(stat.S_IRWXO)
+		# Change permissions to rw-r--r--, default permissions cause issues in WSL.
+		sim.download.location(resource).absolute().chmod(0o644)
 		return send_file(sim.download.location(resource).absolute(), as_attachment=True,mimetype="data")
 
 	return Response(None, 400)


### PR DESCRIPTION
Fixed incorrect permissions caused by `stat.IRWXO` which was initially set due to issues on WSL. File permissions now explicitly set to 644 (rw-r--r--)