### PR TITLE
feat: :sparkles: Detector Energy Response (#43)

### DIFF
--- a/webct/blueprints/app/static/scss/app.scss
+++ b/webct/blueprints/app/static/scss/app.scss
@@ -118,7 +118,7 @@ section.tab:not([active]) {
 }
 
 
-sl-split-panel {
+main > section.content > sl-split-panel {
 	--divider-width: 0.25rem;
 	overflow: hidden;
 	position: fixed;
@@ -196,6 +196,11 @@ aside#imagebar > sl-tooltip > sl-button > sl-icon {
 section #webgl {
 	background-color: var(--sl-color-primary-50);
 	overflow-y: hidden;
+}
+
+// only supported on updated browsers, but cleans up the dividers
+main > section > sl-split-panel > .half-pane:has([type="detector"][active]) {
+	padding: 0rem;
 }
 
 .half-pane {

--- a/webct/blueprints/app/static/scss/group.scss
+++ b/webct/blueprints/app/static/scss/group.scss
@@ -87,5 +87,4 @@ div.group:not([active]) > div > *[advanced]  * {
 div.group[active] > div > [advanced] {
 	opacity: 100;
 	transition: all 0.25s;
-	height: auto;
 }

--- a/webct/blueprints/app/templates/main.html.j2
+++ b/webct/blueprints/app/templates/main.html.j2
@@ -71,28 +71,27 @@ WebCT
 			<sl-progress-bar indeterminate id="barLoading"></sl-progress-bar>
 			<sl-split-panel vertical snap="20% 50% 80%">
 				<sl-icon slot="handle" name="grip-horizontal"></sl-icon>
-			<section class="half-pane" slot="start">
-				<section class="pane" type="beam" active>
-					{% include "pane.beam.html.j2" %}
+				<section class="half-pane" slot="start">
+					<section class="pane" type="beam" active>
+						{% include "pane.beam.html.j2" %}
+					</section>
+					<section class="pane" type="detector">
+						{% include "pane.detector.html.j2" %}
+					</section>
+					<section class="pane" type="samples">
+						{% include "pane.samples.html.j2" %}
+					</section>
+					<section class="pane" type="capture">
+						{% include "pane.capture.html.j2" %}
+					</section>
+					<section class="pane" type="reconstruction">
+						{% include "pane.reconstruction.html.j2" %}
+					</section>
 				</section>
-				<section class="pane" type="detector">
-					{% include "pane.detector.html.j2" %}
+				<section class="half-pane" id="webgl" slot="end">
+					{% include "preview.pane.html.j2" %}
 				</section>
-				<section class="pane" type="samples">
-					{% include "pane.samples.html.j2" %}
-				</section>
-				<section class="pane" type="capture">
-					{% include "pane.capture.html.j2" %}
-				</section>
-				<section class="pane" type="reconstruction">
-					{% include "pane.reconstruction.html.j2" %}
-				</section>
-			</section>
-			<section class="half-pane" id="webgl" slot="end">
-				{# <img src="img/test.svg" alt=""> #}
-				{% include "preview.pane.html.j2" %}
-			</section>
-		</sl-split-panel>
+			</sl-split-panel>
 		</section>
 
 		<div id="appIcons">

--- a/webct/blueprints/app/templates/units/px.html.j2
+++ b/webct/blueprints/app/templates/units/px.html.j2
@@ -1,0 +1,1 @@
+<span slot="suffix">px</span>

--- a/webct/blueprints/detector/routes.py
+++ b/webct/blueprints/detector/routes.py
@@ -1,8 +1,9 @@
+import numpy as np
 from dataclasses import dataclass
 from flask import jsonify, session, request
 from flask.wrappers import Response
 from webct.blueprints.detector import bp
-from webct.components.Detector import DetectorParameters
+from webct.components.Detector import DetectorParameters, EnergyResponse
 from webct.components.sim.SimSession import Sim
 
 
@@ -20,11 +21,13 @@ def setDetector() -> Response:
 @dataclass(frozen=True)
 class DetectorResponse:
 	params: DetectorParameters
+	energyResponse: EnergyResponse
 
 
 @bp.route("/detector/get")
-def getBeam() -> Response:
+def getDetector() -> Response:
 
 	simdata = Sim(session)
-	response = DetectorResponse(simdata.detector)
+	response = DetectorResponse(simdata.detector, simdata.energyResponse())
+
 	return jsonify(response)

--- a/webct/blueprints/detector/routes.py
+++ b/webct/blueprints/detector/routes.py
@@ -28,6 +28,6 @@ class DetectorResponse:
 def getDetector() -> Response:
 
 	simdata = Sim(session)
-	response = DetectorResponse(simdata.detector, simdata.energyResponse())
+	response = DetectorResponse(simdata.detector, simdata.detector.scintillator.response)
 
 	return jsonify(response)

--- a/webct/blueprints/detector/static/scss/detector.scss
+++ b/webct/blueprints/detector/static/scss/detector.scss
@@ -10,10 +10,23 @@
 	stroke: var(--sl-color-neutral-200)
 }
 
-div.LSFGraph {
-	margin-top: 1rem !important; // Force a top margin to give visual space for the graph
+div.group:not([active]) > div > div.LSFGraph[advanced] {
+	margin-top: 0;
+}
+
+div.group[active] > div > div.LSFGraph[advanced] {
+	margin-top: 1rem;
+}
+
+section[type="detector"] > sl-split-panel {
 	width: 100%;
-	height: 300px;
+	height: 100%;
+}
+
+
+div.LSFGraph {
+	width: 100%;
+	height: 20rem;
 	padding: 0;
 	background-color: white;
 	border: var(--sl-color-primary-500);

--- a/webct/blueprints/detector/templates/pane.detector.html.j2
+++ b/webct/blueprints/detector/templates/pane.detector.html.j2
@@ -1,30 +1,29 @@
-<div class="detectorpane">
+<sl-split-panel horizontal snap="20% 50% 80%">
+	<sl-icon slot="handle" name="grip-vertical"></sl-icon>
+	<section class="half-pane" slot="start">
+		<canvas id="canvasEnergyResponse"></canvas>
 
-</div>
-<div class="pane">
-	<svg xmlns="http://www.w3.org/2000/svg" height="100%" width="100%" id="divDetectorPreview">
-		<!-- Diagonals -->
-		<line x1="0" x2="100%" y1="0" y2="100%" style="stroke:var(--sl-color-neutral-500);stroke-width:1.5;stroke-dasharray:7,7;" />
-		<line x1="0" x2="100%" y1="100%" y2="0" style="stroke:var(--sl-color-neutral-500);stroke-width:1.5;stroke-dasharray:7,7;" />
+	</section>
+	<section class="half-pane" slot="end">
+		<svg xmlns="http://www.w3.org/2000/svg" height="100%" width="100%" id="divDetectorPreview">
+			<!-- Diagonals -->
+			<line x1="0" x2="100%" y1="0" y2="100%" style="stroke:var(--sl-color-neutral-500);stroke-width:1.5;stroke-dasharray:7,7;" />
+			<line x1="0" x2="100%" y1="100%" y2="0" style="stroke:var(--sl-color-neutral-500);stroke-width:1.5;stroke-dasharray:7,7;" />
 
-		<!-- Horizontal -->
-		<line x1="0" x2="100%" y1="7%" y2="7%" style="stroke:var(--sl-color-neutral-800);stroke-width:1.5;"></line>
-		<!-- <line x1="0%" x2="0%" y1="2%" y2="12%" style="stroke:var(--sl-color-neutral-800);stroke-width:1.5;"></line>
-		<line x1="100%" x2="100%" y1="2%" y2="12%" style="stroke:var(--sl-color-neutral-800);stroke-width:1.5;"></line> -->
-		<text x="50%" y="12%" text-anchor="middle" id="textDetectorHorizontal">250mm (500px)</text>
+			<!-- Horizontal -->
+			<line x1="0" x2="100%" y1="7%" y2="7%" style="stroke:var(--sl-color-neutral-800);stroke-width:1.5;"></line>
+			<!-- <line x1="0%" x2="0%" y1="2%" y2="12%" style="stroke:var(--sl-color-neutral-800);stroke-width:1.5;"></line>
+			<line x1="100%" x2="100%" y1="2%" y2="12%" style="stroke:var(--sl-color-neutral-800);stroke-width:1.5;"></line> -->
+			<text x="50%" y="12%" text-anchor="middle" id="textDetectorHorizontal">250mm (500px)</text>
 
-		<!-- Vertical -->
-		<line x1="7%" x2="7%" y1="0%" y2="100%" style="stroke:var(--sl-color-neutral-800);stroke-width:1.5;"></line>
-		<!-- <line x1="0%" x2="0%" y1="2%" y2="12%" style="stroke:var(--sl-color-neutral-800);stroke-width:1.5;"></line>
-		<line x1="100%" x2="100%" y1="2%" y2="12%" style="stroke:var(--sl-color-neutral-800);stroke-width:1.5;"></line> -->
-		<text x="12%" y="50%" writing-mode="tb" text-anchor="middle" glyph-orientation-vertical="0" id="textDetectorVertical">250mm (500px)</text>
-	</svg>
-</div>
-
-<sl-divider></sl-divider>
-
-<div class="pane">
-</div>
+			<!-- Vertical -->
+			<line x1="7%" x2="7%" y1="0%" y2="100%" style="stroke:var(--sl-color-neutral-800);stroke-width:1.5;"></line>
+			<!-- <line x1="0%" x2="0%" y1="2%" y2="12%" style="stroke:var(--sl-color-neutral-800);stroke-width:1.5;"></line>
+			<line x1="100%" x2="100%" y1="2%" y2="12%" style="stroke:var(--sl-color-neutral-800);stroke-width:1.5;"></line> -->
+			<text x="12%" y="50%" writing-mode="tb" text-anchor="middle" glyph-orientation-vertical="0" id="textDetectorVertical">250mm (500px)</text>
+		</svg>
+	</section>
+</sl-split-panel>
 
 <sl-dialog label="LSF Editor" id="dialogueLSF">
 	<div>

--- a/webct/blueprints/detector/templates/tab.detector.html.j2
+++ b/webct/blueprints/detector/templates/tab.detector.html.j2
@@ -5,12 +5,21 @@
 
 <div class="group">
 	<div>
-		<sl-input type="number" label="Pane Width" value="640" id="inputPaneWidth">
-			{% include "./units/size.html.j2" %}
-		</sl-input>
-		<sl-input type="number" label="Pane Height" value="320" id="inputPaneHeight">
-			{% include "./units/size.html.j2" %}
-		</sl-input>
+		<div style="grid-template-columns: repeat(2, minmax(0, 1fr)); display: grid;">
+			<sl-input type="number" label="Pane Width" value="640" id="inputPaneWidth">
+				{% include "./units/size.html.j2" %}
+			</sl-input>
+			<sl-input type="number" label="Pane Height" value="320" id="inputPaneHeight">
+				{% include "./units/size.html.j2" %}
+			</sl-input>
+			<sl-input type="number" value="640" id="inputPaneWidthPx">
+				{% include "./units/px.html.j2" %}
+			</sl-input>
+			<sl-input type="number" value="320" id="inputPaneHeightPx">
+				{% include "./units/px.html.j2" %}
+			</sl-input>
+		</div>
+
 		<sl-input type="number" label="Pixel Size" value="0.5" step="0.01" id="inputPanePixelSize">
 			<span slot="suffix">μm</span>
 		</sl-input>
@@ -19,12 +28,74 @@
 
 <div class="group">
 	<div>
-		<sl-button id="buttonShowLSF">LSF Editor
+		<sl-select label="Detector Scintillator" value="" id="selectScintillator">
+			<sl-menu-item value="">Perfect Scintillator
+			</sl-menu-item>
+
+			<sl-divider></sl-divider>
+
+			<sl-menu-item value="CsI">CsI
+				<span> Cesium Iodine</span>
+			</sl-menu-item>
+
+			<sl-menu-item value="NaI">NaI
+				<span> Sodium Iodine</span>
+			</sl-menu-item>
+
+			<sl-menu-item value="Gadox">Gadox
+				<span> Gadolinum silicate (Gd2O2S)</span>
+			</sl-menu-item>
+
+			<sl-divider></sl-divider>
+
+			<sl-menu-item value="Gadox DRZ-Plus">Gadox DRZ Plus
+				<span> Gd2O2S DRZ-Plus</span>
+			</sl-menu-item>
+
+			<sl-menu-item value="Gd2O3">Gd2O3
+				<span> Gadolinum oxyde</span>
+			</sl-menu-item>
+
+			<sl-menu-item value="Gd3Ga5O12">Gd3Ga5O12
+				<span> Gadolinium gallium garnet</span>
+			</sl-menu-item>
+
+			<sl-menu-item value="YGO">YGO
+				<span> Yttrium gadolinum oxyde (Y2Gd2O3)</span>
+			</sl-menu-item>
+
+			<sl-divider></sl-divider>
+
+			<sl-menu-item value="CdWO4">CdWO4
+				<span> Cadmium tungstate</span>
+			</sl-menu-item>
+
+			<sl-menu-item value="Y2O3">Y2O3
+				<span> Yttrium oxyde</span>
+			</sl-menu-item>
+
+			<sl-menu-item value="La2HfO7">La2HfO7
+				<span> Lanthanum hafnate</span>
+			</sl-menu-item>
+
+			<sl-menu-item value="Y3Al5O12">Y3Al5O12
+				<span> Yttrium aluminium garnate</span>
+			</sl-menu-item>
+
+		</sl-select>
+
+		<sl-input type="number" label="Scintillator Thickness" value="200" id="inputScintillatorThickness">
+			<span slot="suffix">μm</span>
+		</sl-input>
+
+		<div class="LSFGraph" advanced>
+			<canvas id="canvasLSF" width="100%"></canvas>
+		</div>
+
+		<sl-button id="buttonShowLSF" advanced>LSF Editor
 			<sl-icon slot="prefix" name="bezier"></sl-icon>
 		</sl-button>
-		<div class="LSFGraph">
-			<canvas id="canvasLSF" width="100%" height="100%"></canvas>
-		</div>
+
 	</div>
-</div>
+	<button></button>
 </div>

--- a/webct/components/sim/Quality.py
+++ b/webct/components/sim/Quality.py
@@ -4,17 +4,17 @@ from enum import IntEnum
 class Quality(IntEnum):
 	# High quality is a pixel-perfect simulation, including full detector size,
 	# and a reconstruction space matching the projection size.
-	HIGH = 0,
+	HIGH = 0
 
 	# Medium quality uses a full detector size for projections, but a reduced
 	# size for the reconstruction space.
-	MEDIUM = 1,
+	MEDIUM = 1
 
 	# Low quality uses a half detector size for projections, and an even more
 	# reduced reconstruction space compared to medium.
-	LOW = 2,
+	LOW = 2
 
 	# Preview uses a fixed detector size of no more than 100 pixels in all axis,
 	# and will keep aspect ratio if one axis exceeds this limit. The
 	# reconstruction space is a fixed 100x100x100 cube.
-	PREVIEW = 3,
+	PREVIEW = 3

--- a/webct/components/sim/SimSession.py
+++ b/webct/components/sim/SimSession.py
@@ -247,17 +247,6 @@ class SimSession:
 			self._scene = self._simClient.getScene()
 			return self._scene
 
-	def energyResponse(self) -> EnergyResponse:
-		with self._lock:
-			if not self._dirty[0] and hasattr(self, "_energy_response") and self._energy_response is not None:
-				print("Using cached energy response")
-				return self._energy_response
-			self._counter += 1
-			print(f"[SC-{self._sid}-{self._simClient.pid}]-Lock-{self._counter}-EnergyResponse")
-
-			self._energy_response = self._simClient.getEnergyResponse()
-			return self._energy_response
-
 	def allProjections(self, quality=Quality.MEDIUM, corrected=True) -> np.ndarray:
 		with self._lock:
 			if not self._dirty[1] and hasattr(self, "_projections") and quality in self._projections:

--- a/webct/components/sim/clients/SimClient.py
+++ b/webct/components/sim/clients/SimClient.py
@@ -13,7 +13,7 @@ from typing import Any, Tuple
 import numpy as np
 from webct.components.Beam import Beam, BeamParameters, Spectra
 from webct.components.Capture import CaptureParameters
-from webct.components.Detector import DetectorParameters, EnergyResponse
+from webct.components.Detector import DetectorParameters
 from webct.components.Samples import RenderedSample
 from webct.components.sim.Quality import Quality
 from webct.components.sim.simulators.GVXRSimulator import GVXRSimulator
@@ -43,10 +43,6 @@ class STM_PROJECTION(STM):
 
 @dataclass(frozen=True)
 class STM_SCENE(STM):
-	pass
-
-@dataclass(frozen=True)
-class STM_DETECTOR_RESPONSE(STM):
 	pass
 
 @dataclass(frozen=True)
@@ -183,13 +179,6 @@ class SimClient(Process):
 				print(f"[SIM-{self.pid}] Creating scene preview")
 				self.conn_child.send(SimResponse.ACCEPTED)
 				energy_response = self._simulator.RenderScene()
-				self.conn_child.send(SimResponse.DONE)
-				self.conn_child.send(energy_response)
-
-			elif isinstance(input, STM_DETECTOR_RESPONSE):
-				print(f"[SIM-{self.pid}] Generating Detector Energy Response")
-				self.conn_child.send(SimResponse.ACCEPTED)
-				energy_response = self._simulator.DetectorEnergyResponse()
 				self.conn_child.send(SimResponse.DONE)
 				self.conn_child.send(energy_response)
 
@@ -490,24 +479,6 @@ class SimClient(Process):
 			if not isinstance(scene, tuple):
 				raise SimThreadError(f"Unexpected scene type of '{type(scene)}', expected 'tuple'")
 			return np.asarray(scene)
-		else:
-			raise SimThreadError(
-				f"Unexpected response: {response}, wanted SimResponse.DONE"
-			)
-
-	def getEnergyResponse(self) -> EnergyResponse:
-		request = STM_DETECTOR_RESPONSE()
-		self.conn_parent.send(request)
-		self.check_confirm()
-		response = self.response(msg="sim timeout while generating energy response.")
-
-		if not isinstance(response, SimResponse):
-			raise SimThreadError(f"Expected a response, but got a {type(response)}")
-		elif response is SimResponse.DONE:
-			energy_response = self.response(msg="sim timeout while generating energy response.")
-			if not isinstance(energy_response, EnergyResponse):
-				raise SimThreadError(f"Unexpected energy response type of '{type(energy_response)}', expected 'np.ndarray'")
-			return energy_response
 		else:
 			raise SimThreadError(
 				f"Unexpected response: {response}, wanted SimResponse.DONE"

--- a/webct/components/sim/simulators/GVXRSimulator.py
+++ b/webct/components/sim/simulators/GVXRSimulator.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from webct.components.Beam import PROJECTION, Beam, LabBeam
 from webct.components.Capture import CaptureParameters
-from webct.components.Detector import DetectorParameters
+from webct.components.Detector import SCINTILLATOR_MATERIAL, DetectorParameters, EnergyResponse
 from webct.components.Material import (
 	CompoundMaterial,
 	ElementMaterial,
@@ -85,6 +85,21 @@ class GVXRSimulator(Simulator):
 
 		return images_in_kev
 
+	def DetectorEnergyResponse(self) -> EnergyResponse:
+		if (self.detector.scintillator.material != SCINTILLATOR_MATERIAL.NONE):
+
+			# coerce tuple into energy response class
+			incident_output = gvxr.getEnergyResponse("keV")
+			response = EnergyResponse(
+				incident=tuple([x[0] for x in incident_output]),
+				output=tuple([x[1] for x in incident_output])
+				)
+
+			return response
+		else:
+			# Perfect linear response if no detector energy response
+			return EnergyResponse(tuple(np.arange(0, 300, dtype=float)), tuple(np.arange(0, 300, dtype=float)))
+
 	@property
 	def beam(self) -> Beam:
 		return self._beam
@@ -160,6 +175,11 @@ class GVXRSimulator(Simulator):
 			gvxr.setDetectorNumberOfPixels(*shape)
 			gvxr.setDetectorPixelSize(value.pixel_size * scale, value.pixel_size * scale, "mm")
 
+		if (value.scintillator.material is not SCINTILLATOR_MATERIAL.NONE) and (value.scintillator.material is not SCINTILLATOR_MATERIAL.CUSTOM):
+			gvxr.setScintillator(str(value.scintillator.material.value), value.scintillator.thickness, "mm")
+		else:
+			gvxr.clearDetectorEnergyResponse()
+
 		self._detector = value
 
 	@property
@@ -200,8 +220,6 @@ class GVXRSimulator(Simulator):
 			gvxr.setColour(label, *colour_from_string(label), 1)
 			gvxr.moveToCenter(label)
 
-
-
 	@property
 	def capture(self) -> CaptureParameters:
 		return self._capture
@@ -238,7 +256,6 @@ class GVXRSimulator(Simulator):
 		self._quality = value
 		# Update detector with new quality settings
 		self.detector = self._detector
-
 
 	def RenderScene(self) -> Tuple[Tuple[float]]:
 		gvxr.displayScene()

--- a/webct/components/sim/simulators/Simulator.py
+++ b/webct/components/sim/simulators/Simulator.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from webct.components.Beam import Beam
 from webct.components.Capture import CaptureParameters
-from webct.components.Detector import DetectorParameters, EnergyResponse
+from webct.components.Detector import DetectorParameters
 from webct.components.Samples import RenderedSample
 from webct.components.sim.Quality import Quality
 
@@ -38,10 +38,6 @@ class Simulator(metaclass=ABCMeta):
 	def SimAllProjections(self) -> np.ndarray:
 		"""Generate all projections of a scene."""
 		raise NotImplementedError()
-
-	@property
-	def DetectorEnergyResponse(self) -> EnergyResponse:
-		...
 
 	@property
 	def beam(self) -> Beam:

--- a/webct/components/sim/simulators/Simulator.py
+++ b/webct/components/sim/simulators/Simulator.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from webct.components.Beam import Beam
 from webct.components.Capture import CaptureParameters
-from webct.components.Detector import DetectorParameters
+from webct.components.Detector import DetectorParameters, EnergyResponse
 from webct.components.Samples import RenderedSample
 from webct.components.sim.Quality import Quality
 
@@ -38,6 +38,10 @@ class Simulator(metaclass=ABCMeta):
 	def SimAllProjections(self) -> np.ndarray:
 		"""Generate all projections of a scene."""
 		raise NotImplementedError()
+
+	@property
+	def DetectorEnergyResponse(self) -> EnergyResponse:
+		...
 
 	@property
 	def beam(self) -> Beam:


### PR DESCRIPTION
Added Scintillator support
- Supports 11 different scintillators
- Change scintillator thickness
- See detector energy response in new graph
- Added GVXR & WebCT Config support for scintillators

See and change detector pixel count
- Now able to change pixel resolution rather than just panel size
	- Changing pixel pitch adjusts either pixel count or panel size, whatever was not changed last
		- Change resolution + change pixel pitch = panel size changes
		- Change panel size + change pixel pitch = resolution changes

LSF graph moved into advanced scintillator options