### PR TITLE
fix: :bug: Use Luminance for Synchrotron sources (#73)

### DIFF
--- a/webct/blueprints/app/static/js/formats/GVXRLoader.ts
+++ b/webct/blueprints/app/static/js/formats/GVXRLoader.ts
@@ -111,7 +111,7 @@ export const GVXRConfig:FormatLoaderStatic = class GVXRConfig implements FormatL
 		if (data.beam.method == "synch") {
 			console.log("beamsynch");
 			const synchBeam:SynchBeam = data.beam as never;
-			const totalCount = synchBeam.exposure * synchBeam.intensity;
+			const totalCount = synchBeam.exposure * synchBeam.flux * 10e10;
 			beam = [{
 				Unit:"keV" as EnergyUnit,
 				Energy: synchBeam.energy,

--- a/webct/blueprints/app/templates/units/photon_flux.html.j2
+++ b/webct/blueprints/app/templates/units/photon_flux.html.j2
@@ -1,0 +1,1 @@
+<span slot="suffix">x10¹⁰ photons/s/cm²</span>

--- a/webct/blueprints/beam/static/js/api.ts
+++ b/webct/blueprints/beam/static/js/api.ts
@@ -40,6 +40,7 @@ export interface BeamResponseRegistry {
 			energy?: number;
 			exposure?:number;
 			intensity?:number;
+			flux?:number;
 			spotSize?:number;
 			material?:number;
 			anodeAngle?:number;
@@ -160,7 +161,7 @@ export function processResponse(data: BeamResponseRegistry["beamResponse"]): [Be
 		beamProperties = new SynchBeam(
 			data.params.energy as number,
 			data.params.exposure as number,
-			data.params.intensity as number,
+			data.params.flux as number,
 			data.params.harmonics as boolean,
 			filters,
 		);

--- a/webct/blueprints/beam/static/js/beam.ts
+++ b/webct/blueprints/beam/static/js/beam.ts
@@ -23,6 +23,7 @@ let BeamEnergyElement: SlInput;
 let BeamExposureElement:SlInput;
 let BeamVoltageElement:SlInput;
 let BeamIntensityElement:SlInput;
+let BeamFluxElement:SlInput;
 let BeamMASElement:SlInput;
 let BeamAngleElement:SlInput;
 let BeamHarmonicsElement:SlCheckbox;
@@ -67,6 +68,7 @@ export function setupBeam(): boolean {
 	const exposure_element = document.getElementById("inputBeamExposure");
 	const voltage_element = document.getElementById("inputBeamVoltage");
 	const intensity_element = document.getElementById("inputBeamIntensity");
+	const flux_element = document.getElementById("inputBeamFlux");
 	const mas_element = document.getElementById("inputBeamMAS");
 	const angle_element = document.getElementById("inputBeamAngle");
 	const spot_size = document.getElementById("inputBeamSpotSize");
@@ -92,6 +94,7 @@ export function setupBeam(): boolean {
 		exposure_element == null ||
 		voltage_element == null ||
 		intensity_element == null ||
+		flux_element == null ||
 		mas_element == null ||
 		angle_element == null ||
 		spot_size == null ||
@@ -112,6 +115,7 @@ export function setupBeam(): boolean {
 		console.log(exposure_element);
 		console.log(voltage_element);
 		console.log(intensity_element);
+		console.log(flux_element);
 		console.log(mas_element);
 		console.log(angle_element);
 		console.log(spot_size);
@@ -136,6 +140,7 @@ export function setupBeam(): boolean {
 	BeamExposureElement = exposure_element as SlInput;
 	BeamVoltageElement = voltage_element as SlInput;
 	BeamIntensityElement = intensity_element as SlInput;
+	BeamFluxElement = flux_element as SlInput;
 	BeamMASElement = mas_element as SlInput;
 	BeamAngleElement = angle_element as SlInput;
 	BeamSpotSizeElement = spot_size as SlInput;
@@ -149,6 +154,7 @@ export function setupBeam(): boolean {
 		BeamExposureElement.classList.add("hidden");
 		BeamVoltageElement.classList.add("hidden");
 		BeamIntensityElement.classList.add("hidden");
+		BeamFluxElement.classList.add("hidden");
 		BeamMASElement.classList.add("hidden");
 		BeamHarmonicsElement.classList.add("hidden");
 		FilterSettings.classList.add("hidden");
@@ -180,7 +186,7 @@ export function setupBeam(): boolean {
 		case "synch":
 			BeamEnergyElement.classList.remove("hidden");
 			BeamExposureElement.classList.remove("hidden");
-			BeamIntensityElement.classList.remove("hidden");
+			BeamFluxElement.classList.remove("hidden");
 			BeamHarmonicsElement.classList.remove("hidden");
 
 			if (AlgElement.value == "FDK") {
@@ -386,7 +392,7 @@ export function getBeamParms():BeamProperties {
 		beam = new SynchBeam(
 			parseFloat(BeamEnergyElement.value as string),
 			parseFloat(BeamExposureElement.value as string),
-			parseFloat(BeamIntensityElement.value as string),
+			parseFloat(BeamFluxElement.value as string),
 			BeamHarmonicsElement.checked,
 			[
 				{
@@ -429,7 +435,7 @@ export function setBeamParams(beam:BeamProperties) {
 		params = beam as SynchBeam;
 		BeamEnergyElement.value = params.energy+"";
 		BeamExposureElement.value = params.exposure+"";
-		BeamIntensityElement.value = params.intensity+"";
+		BeamFluxElement.value = params.flux+"";
 		break;
 	}
 

--- a/webct/blueprints/beam/static/js/beam.ts
+++ b/webct/blueprints/beam/static/js/beam.ts
@@ -147,6 +147,8 @@ export function setupBeam(): boolean {
 	BeamMaterialElement = beam_material_element as SlInput;
 	BeamHarmonicsElement = harmonics_element as SlCheckbox;
 
+	BeamGeneratorElement = beam_generator_element as SlSelect;
+
 	BeamSourceSelectElement = source_select_element as SlSelect;
 	BeamSourceSelectElement.addEventListener("sl-change", () => {
 		TubeSettings.classList.add("hidden");
@@ -158,6 +160,7 @@ export function setupBeam(): boolean {
 		BeamMASElement.classList.add("hidden");
 		BeamHarmonicsElement.classList.add("hidden");
 		FilterSettings.classList.add("hidden");
+		BeamGeneratorElement.classList.add("hidden");
 
 		switch (BeamSourceSelectElement.value as SourceType) {
 		case "lab":
@@ -166,6 +169,7 @@ export function setupBeam(): boolean {
 			BeamIntensityElement.classList.remove("hidden");
 			TubeSettings.classList.remove("hidden");
 			FilterSettings.classList.remove("hidden");
+			BeamGeneratorElement.classList.remove("hidden");
 
 			if (AlgElement.value == "FBP") {
 				AlgElement.value = "FDK";
@@ -177,6 +181,7 @@ export function setupBeam(): boolean {
 			BeamMASElement.classList.remove("hidden");
 			TubeSettings.classList.remove("hidden");
 			FilterSettings.classList.remove("hidden");
+			BeamGeneratorElement.classList.remove("hidden");
 
 			if (AlgElement.value == "FBP") {
 				AlgElement.value = "FDK";
@@ -198,7 +203,6 @@ export function setupBeam(): boolean {
 	});
 	BeamSourceSelectElement.handleValueChange();
 
-	BeamGeneratorElement = beam_generator_element as SlSelect;
 
 	FilterMaterialElement = filter_material_element as SlSelect;
 	FilterSizeElement = filter_size_element as SlInput;

--- a/webct/blueprints/beam/static/js/types.ts
+++ b/webct/blueprints/beam/static/js/types.ts
@@ -105,14 +105,14 @@ export class SynchBeam implements BeamProperties {
 	method = "synch" as const
 	energy: number
 	exposure: number
-	intensity: number
+	flux: number
 	harmonics:boolean
 	filters: Array<Filter>
 
-	constructor(energy:number, exposure:number, intensity:number, harmonics:boolean, filters:Array<Filter>) {
+	constructor(energy:number, exposure:number, flux:number, harmonics:boolean, filters:Array<Filter>) {
 		this.energy = energy;
 		this.exposure = exposure,
-		this.intensity = intensity;
+		this.flux = flux;
 		this.harmonics = harmonics;
 		this.filters = filters;
 	}
@@ -211,7 +211,7 @@ export class SpectraDisplay {
 			break;
 		case "synch":
 			prop = this.beam as SynchBeam;
-			title = prop.energy + "keV beam @ " + prop.intensity + "mA";
+			title = prop.energy + "keV synchrotron beam @ " + prop.flux + "x10¹⁰ photons/s/cm²";
 			break;
 		}
 

--- a/webct/blueprints/beam/templates/tab.beam.html.j2
+++ b/webct/blueprints/beam/templates/tab.beam.html.j2
@@ -22,6 +22,10 @@
 			{% include "./units/voltage.html.j2" %}
 		</sl-input>
 
+		<sl-input type="number" label="Photon Flux" step="0.1" value="1.8" id="inputBeamFlux">
+			{% include "./units/photon_flux.html.j2" %}
+		</sl-input>
+
 		<sl-input type="number" label="Exposure" step="0.01" value="1" id="inputBeamExposure">
 			{% include "./units/exposure.html.j2" %}
 		</sl-input>

--- a/webct/components/Beam.py
+++ b/webct/components/Beam.py
@@ -175,7 +175,7 @@ class SynchBeam(BeamParameters):
 	projection = PROJECTION.PARALLEL
 	energy: float
 	exposure: float
-	intensity: float
+	flux: float
 	harmonics: bool
 
 	def to_json(self) -> dict:
@@ -185,7 +185,7 @@ class SynchBeam(BeamParameters):
 	def from_json(json:dict):
 		energy = float(json["energy"])
 		exposure = float(json["exposure"])
-		intensity = float(json["intensity"])
+		flux = float(json["flux"])
 		harmonics = bool(json["harmonics"])
 
 		filters = parseFilters(json["filters"])
@@ -196,7 +196,7 @@ class SynchBeam(BeamParameters):
 		filters=filters,
 		energy=energy,
 		exposure=exposure,
-		intensity=intensity,
+		flux=flux,
 		harmonics=harmonics,
 		spotSize=0)
 
@@ -226,16 +226,17 @@ def generateSpectra(beam: BeamParameters) -> Tuple[Spectra, Spectra]:
 		params = cast(SynchBeam, beam)
 		# harmonics are two higher order;
 		total_range = int(params.energy * 3 + 10)
+		flux = params.flux * 10e10
 
 		energies = np.arange(0, total_range, dtype=int)
 		photons = np.zeros(total_range)
 		base_energy = int(params.energy)
-		photons[base_energy] = 1000
+		photons[base_energy] = flux
 		if params.harmonics:
 			# Add higher-order harmonics
 			photons[base_energy*3] = photons[base_energy] * 0.01
 			photons[base_energy*2] = photons[base_energy] * 0.03
-			photons[base_energy] = 1000 * 0.96
+			photons[base_energy] = flux * 0.96
 
 		return (Spectra(
 			tuple(energies.astype(float)),

--- a/webct/components/sim/simulators/GVXRSimulator.py
+++ b/webct/components/sim/simulators/GVXRSimulator.py
@@ -2,7 +2,7 @@ from typing import List, Tuple, cast
 from gvxrPython3 import gvxr
 import numpy as np
 
-from webct.components.Beam import PROJECTION, Beam, LabBeam
+from webct.components.Beam import PROJECTION, Beam, LabBeam, SynchBeam
 from webct.components.Capture import CaptureParameters
 from webct.components.Detector import SCINTILLATOR_MATERIAL, DetectorParameters
 from webct.components.Material import (
@@ -121,8 +121,17 @@ class GVXRSimulator(Simulator):
 
 				electron_charge = 1.602e-19  # [C]
 				photon_count = mAs * (1.0e-3 / electron_charge) * (1 / ((self.capture.SDD * 10) ** 2))
-
 				gvxr.setNumberOfPhotonsPerCM2(photon_count)
+			elif isinstance(value.params, SynchBeam):
+				gvxr.enablePoissonNoise()
+				synch = cast(SynchBeam, value.params)
+
+				# flux is x10^10
+				flux = synch.flux * synch.exposure
+				gvxr.setNumberOfPhotonsPerCM2(flux * 10e10)
+			else:
+				gvxr.disablePoissonNoise()
+
 		self._beam = value
 
 	@property


### PR DESCRIPTION
Synchrotron beams now use photon flux (photons/s/cm2) rather than intensity (uA). Additionally Beam spectra generator is now only shown on tube sources.
![image](https://github.com/user-attachments/assets/4e0149d5-5004-4c25-bf7b-1f402f45b40e)


Default value of 1.8 x10^10 photonic flux was selected to match [Diamond Light Source's I12 JEEP Beamline](https://www.diamond.ac.uk/Instruments/Imaging-and-Microscopy/I12/Beamline-Characteristics.html)