### PR TITLE
feat: :sparkles: Transmission Histogram (83)

### DIFF
--- a/webct/blueprints/app/static/js/app.ts
+++ b/webct/blueprints/app/static/js/app.ts
@@ -212,6 +212,14 @@ function setPageLoading(loading: boolean, type: LoadingType = "default", source:
 			button.setAttribute("loading", "true");
 		}
 
+		// special buttons that also update the page, but are not dedicated to that feature.
+		// e.g quick-fire sample rotate buttons
+		let miscButtons = document.getElementsByClassName("button-loadonupdate");
+		for (let index = 0; index < miscButtons.length; index++) {
+			const button = miscButtons[index];
+			button.setAttribute("loading", "true")
+		}
+
 		document.getElementsByTagName("body")[0].style.cursor = "wait";
 
 		LoadingBar.setAttribute("variant", type);
@@ -256,6 +264,14 @@ function setPageLoading(loading: boolean, type: LoadingType = "default", source:
 
 		for (let index = 0; index < ReconButtons.length; index++) {
 			const button = ReconButtons[index];
+			button.removeAttribute("loading");
+		}
+
+		// special buttons that also update the page, but are not dedicated to that feature.
+		// e.g quick-fire sample rotate buttons
+		let miscButtons = document.getElementsByClassName("button-loadonupdate");
+		for (let index = 0; index < miscButtons.length; index++) {
+			const button = miscButtons[index];
 			button.removeAttribute("loading");
 		}
 

--- a/webct/blueprints/capture/static/js/capture.ts
+++ b/webct/blueprints/capture/static/js/capture.ts
@@ -3,13 +3,14 @@
  * @author Iwan Mitchell
  */
 
-import { SlDropdown, SlInput, SlRange, SlSelect } from "@shoelace-style/shoelace";
+import { SlButton, SlDropdown, SlInput, SlRange, SlSelect } from "@shoelace-style/shoelace";
 import { AlertType, showAlert } from "../../../base/static/js/base";
 import { PanePixelSizeElement, PaneWidthElement } from "../../../detector/static/js/detector";
 import { CaptureResponseRegistry, processResponse, requestCaptureData, sendCaptureData, prepareRequest, requestCapturePreview } from "./api";
 import { CaptureConfigError, CaptureRequestError, showError } from "./errors";
 import { CapturePreview, CaptureProperties } from "./types";
 import { validateProjections } from "./validation";
+import { UpdatePage } from "../../../app/static/js/app";
 
 // ====================================================== //
 // ================== Document Elements ================= //
@@ -26,6 +27,8 @@ let DetectorPosZElement: SlInput;
 let SampleRotateXElement: SlInput;
 let SampleRotateYElement: SlInput;
 let SampleRotateZElement: SlInput;
+let ButtonRotateClock45Element: SlButton;
+let ButtonRotateCounterClock45Element: SlButton;
 
 let PreviewImages: NodeListOf<HTMLImageElement>;
 let PreviewOverlays: NodeListOf<HTMLDivElement>;
@@ -65,6 +68,9 @@ export function setupCapture(): boolean {
 	const sample_rotatey_element = document.getElementById("inputSampleRotateY");
 	const sample_rotatez_element = document.getElementById("inputSampleRotateZ");
 
+	const sample_rotate_counter_clock_45_element = document.getElementById("buttonSampleRotateCounterClock45");
+	const sample_rotate_clock_45_element = document.getElementById("buttonSampleRotateClock45");
+
 	const range_nyquist = document.getElementById("rangeNyquist");
 
 	if (total_rotation_element == null ||
@@ -75,6 +81,8 @@ export function setupCapture(): boolean {
 		sample_rotatex_element == null ||
 		sample_rotatey_element == null ||
 		sample_rotatez_element == null ||
+		sample_rotate_counter_clock_45_element == null ||
+		sample_rotate_clock_45_element == null ||
 		detector_posx_element == null ||
 		detector_posy_element == null ||
 		detector_posz_element == null ||
@@ -94,6 +102,8 @@ export function setupCapture(): boolean {
 		console.log(sample_rotatex_element);
 		console.log(sample_rotatey_element);
 		console.log(sample_rotatez_element);
+		console.log(sample_rotate_clock_45_element);
+		console.log(sample_rotate_counter_clock_45_element);
 		console.log(range_nyquist);
 
 		showAlert("Capture setup failure", AlertType.ERROR);
@@ -116,6 +126,8 @@ export function setupCapture(): boolean {
 	SampleRotateXElement = sample_rotatex_element as SlInput;
 	SampleRotateYElement = sample_rotatey_element as SlInput;
 	SampleRotateZElement = sample_rotatez_element as SlInput;
+	ButtonRotateClock45Element = sample_rotate_clock_45_element as SlButton;
+	ButtonRotateCounterClock45Element = sample_rotate_counter_clock_45_element as SlButton;
 
 	// Workaround hack to deal with styling annoying shadowroot classes
 	Array.prototype.slice.call(document.getElementsByTagName("sl-dropdown")).forEach((dropdown: SlDropdown) => {
@@ -151,6 +163,17 @@ export function setupCapture(): boolean {
 			image.classList.remove("invert");
 		});
 	}
+
+	ButtonRotateClock45Element.onclick = () => {
+		SampleRotateZElement.value = (parseFloat(SampleRotateZElement.value) + 45) % 360 + "";
+		UpdatePage();
+	};
+	ButtonRotateCounterClock45Element.onclick = () => {
+		let rot = (parseFloat(SampleRotateZElement.value) - 45)
+		if (rot < 0) { rot += 360 }
+		SampleRotateZElement.value = rot + "";
+		UpdatePage();
+	};
 
 	validateCapture();
 	SetOverlaySize(300, 300);

--- a/webct/blueprints/capture/templates/tab.capture.html.j2
+++ b/webct/blueprints/capture/templates/tab.capture.html.j2
@@ -36,6 +36,10 @@
 			<sl-input label="Yaw" type="number" min="0" max="360" step="0.1"   id="inputSampleRotateY"></sl-input>
 			<sl-input label="Roll" type="number" min="0" max="360" step="0.1"  id="inputSampleRotateZ"></sl-input>
 		</div>
+		<sl-button-group label="Quick Rotate">
+			<sl-button class="button-loadonupdate" id="buttonSampleRotateCounterClock45"><sl-icon slot="prefix" name="arrow-counterclockwise"></sl-icon>-45°</sl-button>
+			<sl-button class="button-loadonupdate" id="buttonSampleRotateClock45"><sl-icon slot="suffix" name="arrow-clockwise"></sl-icon>+45°</sl-button>
+		</sl-button-group>
 	</div>
 </div>
 

--- a/webct/blueprints/detector/static/js/detector.ts
+++ b/webct/blueprints/detector/static/js/detector.ts
@@ -8,7 +8,7 @@ import { AlertType, showAlert } from "../../../base/static/js/base";
 import { SetPreviewSize } from "../../../preview/static/js/sim/projection";
 import { DetectorResponseRegistry, prepareRequest, processResponse, requestDetectorData, sendDetectorData } from "./api";
 import { DetectorConfigError, DetectorRequestError, showError } from "./errors";
-import { DetectorProperties, EnergyResponseData, EnergyResponseDisplay, LSF, LSFDisplay, LSFParseEnum, ScintillatorMaterial } from "./types";
+import { DetectorProperties, EnergyResponseDisplay, LSF, LSFDisplay, LSFParseEnum, ScintillatorMaterial } from "./types";
 import { validateHeight, validatePixel, validateWidth } from "./validation";
 
 // ====================================================== //

--- a/webct/blueprints/preview/static/js/sim/api.ts
+++ b/webct/blueprints/preview/static/js/sim/api.ts
@@ -35,9 +35,16 @@ export interface SimResponseRegistry {
 	simResponse: {
 		time:number,
 		projection: {
-			image:string,
+			image: {
+				raw:string,
+				log:string,
+			},
 			height:number,
-			width:number
+			width:number,
+			transmission: {
+				hist:number[],
+				image:string,
+			}
 		},
 		layout: {
 			image:string,
@@ -74,9 +81,16 @@ export function processResponse(data: SimResponseRegistry["simResponse"]): Previ
 	const preview: PreviewData = {
 		time: data.time,
 		projection: {
-			image: data.projection.image,
+			image: {
+				raw: data.projection.image.raw,
+				log: data.projection.image.log
+			},
 			height: data.projection.height,
 			width: data.projection.width,
+			transmission: {
+				hist: data.projection.transmission.hist,
+				image: data.projection.transmission.image
+			},
 		},
 		layout: {
 			image: data.layout.image,

--- a/webct/blueprints/preview/static/js/sim/types.ts
+++ b/webct/blueprints/preview/static/js/sim/types.ts
@@ -1,9 +1,21 @@
+import { ChartOptions } from "chart.js";
+import { Chart } from "chart.js";
+import { colors } from "../../../../base/static/js/colors";
+//! Chart.js elements must already be registered with Chart.register(...registerables)
+
 export interface PreviewData {
 	time:number,
 	projection: {
-		image:string,
+		image: {
+			raw:string,
+			log:string,
+		},
 		height:number,
-		width:number
+		width:number,
+		transmission: {
+			hist:number[],
+			image:string
+		}
 	},
 	layout: {
 		image:string,
@@ -14,5 +26,123 @@ export interface PreviewData {
 		image:string,
 		height:number,
 		width:number
+	}
+}
+
+/**
+ * Spectra display class linked to spectra data and a canvas.
+ */
+export class TransmissionDisplay {
+	readonly previewData: PreviewData
+	readonly canvas: HTMLCanvasElement
+	_chart?: Chart;
+
+	constructor(previewData: PreviewData, canvas: HTMLCanvasElement) {
+		this.previewData = previewData;
+		this.canvas = canvas;
+
+		// Obtain a chart item if it already exists on the given canvas.
+		if (Chart.getChart(this.canvas) !== undefined) {
+			this._chart = Chart.getChart(this.canvas);
+		}
+	}
+
+	public displayTransmission(): void {
+
+		let title = "Image Transmission";
+		let label = "Transmission";
+
+		const chartOptions: ChartOptions = {
+			indexAxis: 'y',
+			responsive: true,
+			maintainAspectRatio: false,
+			scales: {
+				y: {
+					// afterBuildTicks: axis => axis.ticks = [0.0, 5.0, 100.0].map(v => ({ value: v })),
+					beginAtZero: true,
+					ticks: {
+						display: true,
+						callback: (tickValue, index, ticks) => {
+							return parseInt(tickValue + "") + "%";
+						},
+					},
+					grid: {
+						display: true,
+						drawTicks: false,
+					},
+					title: {
+						display: true,
+						text: "Transmission (%)",
+					},
+				},
+				x: {
+					ticks: {
+						display: true,
+						callback: (tickValue, index, ticks) => {
+							return parseFloat(tickValue + "").toFixed(2) + "%";
+						},
+					},
+					grid: {
+						display: true,
+					},
+					title: {
+						display: true,
+						text: "Image Percentage",
+					},
+				}
+			},
+			plugins: {
+				title: {
+					display: true,
+					text: title
+				},
+				legend: {
+					display: false,
+				},
+				tooltip: {
+					callbacks: {
+						// label: (tooltipItem) => {
+						// 	return tooltipItem.dataset.label + ": " + tooltipItem.parsed.y.toFixed(2) + "keV"
+						// },
+						title: (tooltipItems) => {
+							return tooltipItems[0].parsed.y.toFixed(0) + "% Transmission: " + tooltipItems[0].parsed.x.toFixed(2) + "% of pixels.";
+						},
+					}
+				}
+			}
+		};
+
+
+		var barcolors = [colors["red-500"]];
+		barcolors.length = this.previewData.projection.transmission.hist.length
+		barcolors = barcolors.fill(colors["grey-500"], 0, barcolors.length)
+		barcolors = barcolors.fill(colors["red-500"], 0, 6)
+
+		// ? Unknown type for dealing with chart.js dataset configurations
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const TransmissionSettings: any = {
+			label: label,
+			backgroundColor: barcolors,
+			borderColor: barcolors,
+			barPercentage: 1,
+			cubicInterpolationMode: "monotone",
+			borderDash: undefined,
+			fill: false,
+			radius: 0,
+			data: this.previewData.projection.transmission.hist,
+		};
+
+		this._chart?.destroy();
+
+		this._chart = new Chart(this.canvas, {
+			type: "bar",
+			data: {
+				labels: this.previewData.projection.transmission.hist,
+				datasets: [TransmissionSettings],
+			},
+			options: chartOptions
+		});
+
+		this._chart.update();
 	}
 }

--- a/webct/blueprints/preview/static/scss/previews.scss
+++ b/webct/blueprints/preview/static/scss/previews.scss
@@ -42,6 +42,10 @@ img.error {
 	height: 100%;
 	width: 100%;
 	box-sizing: border-box;
+	
+	// sidebar pushes content 100% down, so move image back up.
+	// Can't use fixed positioning on sidebar due to resizing elements.
+	transform: translate(0, -100%);
 }
 
 .previewContainer {
@@ -86,12 +90,35 @@ img.image-layout {
 	display: none;
 }
 
-#webgl > #previewSettings {
+#previewSettings {
 	height: 0;
+	z-index: 11;
+	position: relative;
 }
 
 #settingsPane:not([selected=projection]) {
 	display: none;
+}
+
+#previewGraphContainer:not([selected=projection]) {
+	display: none;
+}
+
+#previewSidebar {
+	// overlap image preview
+	z-index: 1;
+	width: 14rem;
+	position: relative;
+	height: inherit;
+	display: flex;
+	flex-direction: column;
+}
+
+#previewGraphContainer {
+	height: 100%;
+	width: 100%;
+	flex-grow: 1;
+	flex-shrink: 1;
 }
 
 #previewSettings > sl-button-group > sl-button {
@@ -143,13 +170,14 @@ img.image-layout {
 	height: auto;
 	padding-top: 0.5rem;
 	width: 14rem;
-	position: fixed;
 	border-radius: 0.9rem;
 	background-color: var(--sl-color-primary-50);
 	border-color: var(--sl-color-primary-500);
 	border-style: groove;
 	border-width: 1px;
 	box-sizing: border-box;
+	flex-shrink: 0;
+	flex-grow: 1;
 }
 
 #settingsPane > button {

--- a/webct/blueprints/preview/templates/preview.pane.html.j2
+++ b/webct/blueprints/preview/templates/preview.pane.html.j2
@@ -5,18 +5,27 @@
 	</sl-button-group>
 </div>
 
-<div id="settingsPane">
-	<div>
-		<sl-radio-group>
-			<sl-radio value="1" checked id="radioRawProjectionSetting">Raw Projection</sl-radio>
-			<sl-radio value="2" id="radioLogProjectionSetting">Log Projection</sl-radio>
-			<sl-radio value="3" disabled>Gamma Projection</sl-radio>
-			<sl-range disabled min="0" max="1" step="0.1" label="Gamma Value"></sl-range>
-		</sl-radio-group>
-		<sl-checkbox id="checkboxInvertSetting">Invert Colours</sl-checkbox>
+<div id="previewSidebar">
+	<div id="settingsPane">
+		<div>
+			<sl-radio-group>
+				<sl-radio value="1" checked id="radioRawProjectionSetting">Raw Projection</sl-radio>
+				<sl-radio value="2" id="radioLogProjectionSetting">Log Projection</sl-radio>
+				<sl-radio value="3" id="radioTransmissionProjectionSetting">Transmission Hotspot</sl-radio>
+			</sl-radio-group>
+			<sl-checkbox id="checkboxInvertSetting">Invert Colours</sl-checkbox>
+		</div>
+		<!-- id is a workaround for chart.js bugs -->
+		<button id="previewSettingsButton"></button>
+	
 	</div>
-	<button></button>
+	
+	<div id="previewGraphContainer">
+		<canvas id="previewTransmissionGraph"></canvas>
+	</div>
 </div>
+
+
 
 <div id="previewPane" class="previewContainer" selected="projection">
 


### PR DESCRIPTION
Capture:
- Added support for any button to trigger page update and become set to loading
- Added -45/+45 quick rotation buttons Projection preview settings:
- Added transmission histogram, with red highlight for <5% transmission
	- This took far too long due to a scaling bug in chart.js
- Fixed raw / log preview settings, they now work correctly.
- Added "Transmission Hotspot" setting to highlight areas with <5% transmission
- Removed not-implemented gamma setting
	- This would require a rewrite of the projection preview system to implement well. (e.g using the client to render images, and replacing all images with editable canvases, and perform image processing in js)