### PR TITLE
fix: :bug: Sample rotation settings alter the rotation axis and CIL geometry is not updated correctly (#104)

### DIFF
--- a/webct/components/sim/simulators/GVXRSimulator.py
+++ b/webct/components/sim/simulators/GVXRSimulator.py
@@ -230,14 +230,14 @@ class GVXRSimulator(Simulator):
 		self.beam = self._beam
 
 		# Undo rotations in order to reset scene rotation matrix
-		gvxr.rotateScene(-1 * self.total_rotation[2], 0, 0, 1)
-		gvxr.rotateScene(-1 * self.total_rotation[1], 0, 1, 0)
-		gvxr.rotateScene(-1 * self.total_rotation[0], 1, 0, 0)
+		gvxr.rotateNode("root", -1 * self.total_rotation[2], 0, 0, 1)
+		gvxr.rotateNode("root", -1 * self.total_rotation[1], 0, 1, 0)
+		gvxr.rotateNode("root", -1 * self.total_rotation[0], 1, 0, 0)
 		self.total_rotation = value.sample_rotation
 
-		gvxr.rotateScene(value.sample_rotation[0], 1, 0, 0)
-		gvxr.rotateScene(value.sample_rotation[1], 0, 1, 0)
-		gvxr.rotateScene(value.sample_rotation[2], 0, 0, 1)
+		gvxr.rotateNode("root", value.sample_rotation[0], 1, 0, 0)
+		gvxr.rotateNode("root", value.sample_rotation[1], 0, 1, 0)
+		gvxr.rotateNode("root", value.sample_rotation[2], 0, 0, 1)
 		self._capture = value
 
 


### PR DESCRIPTION
Fixes #104 by rotating around the root node rather than per-model rotation
![image](https://github.com/user-attachments/assets/728869c4-feda-493e-9397-d704aeb3c8bd)
