### PR TITLE
feat: :sparkles: Laminography (#109)

### DIFF
--- a/webct/blueprints/app/static/js/formats/ScanDocuLoader.ts
+++ b/webct/blueprints/app/static/js/formats/ScanDocuLoader.ts
@@ -50,7 +50,7 @@ export const ScanDocuConfig: FormatLoaderStatic = class ScanDocuConfig implement
 		let beam: BeamProperties
 
 		// no filter
-		const filter = {			
+		const filter = {
 			thickness: 0,
 			material: ElementSymbols.Cu,
 		}
@@ -82,7 +82,8 @@ export const ScanDocuConfig: FormatLoaderStatic = class ScanDocuConfig implement
 				detectorPosition: [0, this.geometry.ObjectDetectorDist, 0],
 				numProjections: this.recon.ProjectionCountPer360deg ?? 360,
 				sampleRotation: [0, 0, 0],
-				totalAngle: 360
+				totalAngle: 360,
+				laminographyMode: false
 			}
 		};
 	};
@@ -142,7 +143,7 @@ export const ScanDocuConfig: FormatLoaderStatic = class ScanDocuConfig implement
 			if (prop == "SourceDetectorDist") { geo["SourceDetectorDist"] = parseFloat(value)}
 			else if (prop == "SourceObjectDist") { geo["SourceObjectDist"] = parseFloat(value)}
 			else if (prop == "ObjectDetectorDist") { geo["ObjectDetectorDist"] = parseFloat(value)}
-			
+
 			// Recon
 			else if (prop == "ProjectionCount") { recon["ProjectionCount"] = parseInt(value)}
 			else if (prop == "ProjectionCountPer360deg") { recon["ProjectionCountPer360deg"] = parseInt(value)}

--- a/webct/blueprints/app/static/js/formats/XTEKCTLoader.ts
+++ b/webct/blueprints/app/static/js/formats/XTEKCTLoader.ts
@@ -141,7 +141,8 @@ export const XTEKCTConfig: FormatLoaderStatic = class XTEKCTConfig implements Fo
 				detectorPosition: [0, this.config.SrcToDetector - this.config.SrcToObject, 0],
 				numProjections: this.config.Projections ?? 360,
 				sampleRotation: [0, 0, 0],
-				totalAngle: this.config.AngularStep * this.config.Projections < 270 ? 180 : 360
+				totalAngle: this.config.AngularStep * this.config.Projections < 270 ? 180 : 360,
+				laminographyMode: false
 			}
 		};
 	};
@@ -227,7 +228,7 @@ DICOMTags=${this.config.DICOMTags}
 		if (data.beam.method == "synch") {
 			throw "Nikon XTEKCT does not support synchrotron sources."
 		}
-		
+
 		let sdd = (data.capture.beamPosition[1] *-1) + data.capture.detectorPosition[1]
 		let sod = data.capture.beamPosition[1] * -1
 		let VoxelSize = sod  / sdd * data.detector.pixelSize
@@ -320,7 +321,7 @@ DICOMTags=${this.config.DICOMTags}
 			let prop = line.split("=")[0]
 			let value = line.split("=")[1]
 			console.log(prop +": " + value);
-			
+
 			// File metadata
 			if (prop == "Name") { config["Name"] = value }
 

--- a/webct/blueprints/beam/static/js/validation.ts
+++ b/webct/blueprints/beam/static/js/validation.ts
@@ -40,9 +40,8 @@ const VoltageValidators = new Map<string, Validator>([
 ]);
 
 /**
- * Validate Voltage input of X-Ray Tube.
- * @param VoltageElement - Tube Voltage Input to validate.
- * @param material - Material of X-Ray Tube.
+ * Validate Spot Size Thickness text input.
+ * @param SpotSizeElement - Spot Size Thickness input to validate.
  * @returns True if input is valid, false otherwise. Side effect: Passed element will have help-text displaying the validation failure reason.
  */
 export function validateVoltage(VoltageElement: SlInput, material: SupportedAnodes): Valid {
@@ -66,6 +65,7 @@ const AngleValidator: Validator = {
 	message: "Anode Angle must be larger than 0, and less than 179 degrees."
 };
 
+
 /**
  * Validate Anode Angle text input.
  * @param AngleElement - Angle Input to validate.
@@ -84,6 +84,7 @@ const FilterValidator: Validator = {
 	type: "number",
 	message: "Filter thickness cannot be negative. Set to 0mm to disable."
 };
+
 
 /**
  * Validate Filter Thickness text input.

--- a/webct/blueprints/capture/static/js/api.ts
+++ b/webct/blueprints/capture/static/js/api.ts
@@ -39,6 +39,7 @@ export interface CaptureResponseRegistry {
 		detector_position: [number, number, number];
 		beam_position: [number, number, number];
 		sample_rotation: [number, number, number];
+		laminography_mode: boolean;
 	};
 	/**
 	 * Response given when retrieving a preview of the capture plan.
@@ -68,6 +69,7 @@ export interface CaptureRequestRegistry {
 		detector_position: [number, number, number];
 		beam_position: [number, number, number];
 		sample_rotation: [number, number, number];
+		laminography_mode: boolean;
 	}
 }
 
@@ -133,6 +135,7 @@ export function processResponse(data: CaptureResponseRegistry[keyof CaptureRespo
 			beamPosition: data.beam_position,
 			detectorPosition: data.detector_position,
 			sampleRotation: data.sample_rotation,
+			laminographyMode: data.laminography_mode,
 		};
 	}
 }
@@ -148,5 +151,6 @@ export function prepareRequest(data: CaptureProperties): CaptureRequestRegistry[
 		beam_position:data.beamPosition,
 		detector_position:data.detectorPosition,
 		sample_rotation:data.sampleRotation,
+		laminography_mode: data.laminographyMode,
 	};
 }

--- a/webct/blueprints/capture/static/js/capture.ts
+++ b/webct/blueprints/capture/static/js/capture.ts
@@ -3,13 +3,13 @@
  * @author Iwan Mitchell
  */
 
-import { SlButton, SlDropdown, SlInput, SlRange, SlSelect } from "@shoelace-style/shoelace";
+import { SlButton, SlCheckbox, SlDropdown, SlInput, SlRange, SlSelect } from "@shoelace-style/shoelace";
 import { AlertType, showAlert } from "../../../base/static/js/base";
 import { PanePixelSizeElement, PaneWidthElement, validateDetector } from "../../../detector/static/js/detector";
 import { CaptureResponseRegistry, processResponse, requestCaptureData, sendCaptureData, prepareRequest, requestCapturePreview } from "./api";
 import { CaptureConfigError, CaptureRequestError, showError, showValidationError } from "./errors";
 import { CapturePreview, CaptureProperties } from "./types";
-import { validateSourcePosition, validateProjections, validateRotation, validateDetectorPosition } from "./validation";
+import { validateSourcePosition, validateProjections, validateRotation, validateDetectorPosition, validateSceneRotation } from "./validation";
 import { UpdatePage } from "../../../app/static/js/app";
 import { Valid } from "../../../base/static/js/validation";
 
@@ -37,6 +37,8 @@ let ButtonRotateCounterClock45Element: SlButton;
 
 let PreviewImages: NodeListOf<HTMLImageElement>;
 let PreviewOverlays: NodeListOf<HTMLDivElement>;
+
+let CheckboxLaminographyElement: SlCheckbox;
 
 let NyquistRange: SlRange;
 
@@ -81,6 +83,7 @@ export function setupCapture(): boolean {
 	const sample_rotate_counter_clock_45_element = document.getElementById("buttonSampleRotateCounterClock45");
 	const sample_rotate_clock_45_element = document.getElementById("buttonSampleRotateClock45");
 
+	const laminography_enabled_element = document.getElementById("checkboxLaminographyEnabled");
 	const range_nyquist = document.getElementById("rangeNyquist");
 
 	if (total_rotation_element == null ||
@@ -100,6 +103,7 @@ export function setupCapture(): boolean {
 		detector_posx_element == null ||
 		detector_posy_element == null ||
 		detector_posz_element == null ||
+		laminography_enabled_element == null ||
 		range_nyquist == null) {
 
 		console.log(total_rotation_element);
@@ -123,6 +127,9 @@ export function setupCapture(): boolean {
 
 		console.log(sample_rotate_clock_45_element);
 		console.log(sample_rotate_counter_clock_45_element);
+
+		console.log(laminography_enabled_element)
+
 		console.log(range_nyquist);
 
 		showAlert("Capture setup failure", AlertType.ERROR);
@@ -168,6 +175,9 @@ export function setupCapture(): boolean {
 			validateRotation(element);
 		})
 	});
+
+	CheckboxLaminographyElement = laminography_enabled_element as SlCheckbox;
+
 	ButtonRotateClock45Element = sample_rotate_clock_45_element as SlButton;
 	ButtonRotateCounterClock45Element = sample_rotate_counter_clock_45_element as SlButton;
 
@@ -251,9 +261,9 @@ export function validateCapture(): void {
 	let validationResults:Valid[] = []
 	validationResults = [
 		validateProjections(TotalProjectionsElement),
-		validateRotation(SampleRotateXElement),
 
 		// sample rotation
+		validateRotation(SampleRotateXElement),
 		validateRotation(SampleRotateYElement),
 		validateRotation(SampleRotateZElement),
 		// panel positon
@@ -489,6 +499,7 @@ export function getCaptureParams():CaptureProperties {
 		beamPosition: [parseFloat(BeamPosXElement.value), parseFloat(BeamPosYElement.value), parseFloat(BeamPosZElement.value)],
 		detectorPosition: [parseFloat(DetectorPosXElement.value), parseFloat(DetectorPosYElement.value), parseFloat(DetectorPosZElement.value)],
 		sampleRotation: [parseFloat(SampleRotateXElement.value), parseFloat(SampleRotateYElement.value), parseFloat(SampleRotateZElement.value)],
+		laminographyMode: CheckboxLaminographyElement.checked,
 	};
 }
 
@@ -509,6 +520,8 @@ export function setCaptureParams(properties:CaptureProperties) {
 	SampleRotateXElement.value = properties.sampleRotation[0] + "";
 	SampleRotateYElement.value = properties.sampleRotation[1] + "";
 	SampleRotateZElement.value = properties.sampleRotation[2] + "";
+
+	CheckboxLaminographyElement.checked = properties.laminographyMode;
 
 	let pct = ((properties.beamPosition[1] * -1) / ((properties.beamPosition[1]* -1) + properties.detectorPosition[1])) * 100
 	console.log(properties);

--- a/webct/blueprints/capture/static/js/types.ts
+++ b/webct/blueprints/capture/static/js/types.ts
@@ -28,6 +28,10 @@ export interface CaptureProperties {
 	 * Rotation of sample in degrees.
 	 */
 	sampleRotation: [number, number, number];
+	/**
+	 * Enable laminography mode (rotation followes model axis)
+	 */
+	laminographyMode: boolean;
 }
 
 export interface CapturePreview {

--- a/webct/blueprints/capture/static/js/validation.ts
+++ b/webct/blueprints/capture/static/js/validation.ts
@@ -28,7 +28,7 @@ const RotationValidator:Validator = {
 	message: "Rotation must be a number."
 }
 /**
- * Validate Rotation text input.
+ * Validate Sample Rotation text input.
  * @param RotationElement - Rotation input to validate.
  * @returns True if input is valid, False otherwise. Side Effect: passed element will have help-text displaying the validation failure reason.
  */
@@ -36,6 +36,14 @@ export function validateRotation(RotationElement: SlInput): Valid {
 	return validateInput(RotationElement, "Sample Rotation", RotationValidator);
 }
 
+/**
+ * Validate Scene Rotation text input.
+ * @param RotationElement - Rotation input to validate.
+ * @returns True if input is valid, False otherwise. Side Effect: passed element will have help-text displaying the validation failure reason.
+ */
+export function validateSceneRotation(RotationElement: SlInput): Valid {
+	return validateInput(RotationElement, "Scene Rotation", RotationValidator);
+}
 /**
  * Position Validator
  */

--- a/webct/blueprints/capture/templates/tab.capture.html.j2
+++ b/webct/blueprints/capture/templates/tab.capture.html.j2
@@ -40,6 +40,10 @@
 			<sl-button class="button-loadonupdate" id="buttonSampleRotateCounterClock45"><sl-icon slot="prefix" name="arrow-counterclockwise"></sl-icon>-45°</sl-button>
 			<sl-button class="button-loadonupdate" id="buttonSampleRotateClock45"><sl-icon slot="suffix" name="arrow-clockwise"></sl-icon>+45°</sl-button>
 		</sl-button-group>
+
+		<sl-checkbox id="checkboxLaminographyEnabled">Enable Laminography Mode</sl-checkbox>
+		<p>Laminography mode rotates the rotation axis, rather than the sample.</p>
+		</div>
 	</div>
 </div>
 

--- a/webct/components/Capture.py
+++ b/webct/components/Capture.py
@@ -11,6 +11,7 @@ class CaptureParameters:
 	detector_position: Tuple[float, float, float]
 	beam_position: Tuple[float, float, float]
 	sample_rotation: Tuple[float, float, float]
+	laminography_mode: bool
 
 	@property
 	def angles(self) -> np.ndarray:
@@ -34,6 +35,7 @@ class CaptureParameters:
 			or "beam_position" not in json
 			or "detector_position" not in json
 			or "sample_rotation" not in json
+			or "laminography_mode" not in json
 		):
 			raise ValueError("Missing keys.")
 
@@ -42,6 +44,7 @@ class CaptureParameters:
 		tuple(json["beam_position"])
 		tuple(json["detector_position"])
 		tuple(json["sample_rotation"])
+		bool(json["laminography_mode"])
 
 		# Number of projections
 		projections = int(json["projections"])
@@ -73,10 +76,14 @@ class CaptureParameters:
 			raise ValueError(f"Sample rotation must contain three axis. ({len(sample_rot)} was given).")
 		sample_rot = [float(x) for x in sample_rot]
 
+		# Laminography mode (rotate around sample's axis)
+		laminography = bool(json["laminography_mode"])
+
 		return CaptureParameters(
 			projections=projections,
 			capture_angle=capture_angle,
 			detector_position=detector_pos,
 			beam_position=beam_pos,
 			sample_rotation=sample_rot,
+			laminography_mode=laminography,
 		)

--- a/webct/components/sim/simulators/GVXRSimulator.py
+++ b/webct/components/sim/simulators/GVXRSimulator.py
@@ -34,6 +34,7 @@ def colour_from_string(string:str) -> Tuple[float,float,float]:
 
 class GVXRSimulator(Simulator):
 	total_rotation: Tuple[float, float, float] = (0, 0, 0)
+	laminography: bool = False
 	"""
 	X-Ray simulator implemented using gvirtualxray.
 	"""
@@ -230,19 +231,32 @@ class GVXRSimulator(Simulator):
 		self.beam = self._beam
 
 		# Undo rotations in order to reset scene rotation matrix
-		gvxr.rotateNode("root", -1 * self.total_rotation[2], 0, 0, 1)
-		gvxr.rotateNode("root", -1 * self.total_rotation[1], 0, 1, 0)
-		gvxr.rotateNode("root", -1 * self.total_rotation[0], 1, 0, 0)
+		if self.laminography:
+			gvxr.rotateScene(-1 * self.total_rotation[2], 0, 0, 1)
+			gvxr.rotateScene(-1 * self.total_rotation[1], 0, 1, 0)
+			gvxr.rotateScene(-1 * self.total_rotation[0], 1, 0, 0)
+		else:
+			gvxr.rotateNode("root", -1 * self.total_rotation[2], 0, 0, 1)
+			gvxr.rotateNode("root", -1 * self.total_rotation[1], 0, 1, 0)
+			gvxr.rotateNode("root", -1 * self.total_rotation[0], 1, 0, 0)
+
+		self.laminography = value.laminography_mode
 		self.total_rotation = value.sample_rotation
 
-		gvxr.rotateNode("root", value.sample_rotation[0], 1, 0, 0)
-		gvxr.rotateNode("root", value.sample_rotation[1], 0, 1, 0)
-		gvxr.rotateNode("root", value.sample_rotation[2], 0, 0, 1)
+		if self.laminography:
+			gvxr.rotateScene(value.sample_rotation[0], 1, 0, 0)
+			gvxr.rotateScene(value.sample_rotation[1], 0, 1, 0)
+			gvxr.rotateScene(value.sample_rotation[2], 0, 0, 1)
+		else:
+			gvxr.rotateNode("root", value.sample_rotation[0], 1, 0, 0)
+			gvxr.rotateNode("root", value.sample_rotation[1], 0, 1, 0)
+			gvxr.rotateNode("root", value.sample_rotation[2], 0, 0, 1)
 		self._capture = value
 
 
 	def RenderScene(self) -> Tuple[Tuple[float]]:
 		gvxr.displayScene()
+		# gvxr.renderLoop()
 
 		# Zoom scene
 		dist = np.asarray(gvxr.getDetectorPosition("mm")) - np.asarray(gvxr.getSourcePosition("mm"))


### PR DESCRIPTION
Added Laminography mode. This mode rotates the rotation axis rather than the sample, making it great for low-profile objects.

This is done by rotating the scene rather than root node in gVXR if the boolean is enabled, along with passing the new rotation vector to CIL.

Checks were added to CIL to use ASTRA for FBP when using a tilted rotation axis.