### PR TITLE
feat: :sparkles: Uploading a sample adds it automatically (#112)

### DIFF
--- a/webct/blueprints/samples/static/js/validation.ts
+++ b/webct/blueprints/samples/static/js/validation.ts
@@ -4,7 +4,8 @@
  */
 
 import { SlInput } from "@shoelace-style/shoelace";
-import { Valid, validateInputWithHelptext, Validator } from "../../../base/static/js/validation";
+import { markValid, Valid, validateInput, validateInputWithHelptext, Validator } from "../../../base/static/js/validation";
+import { SampleProperties } from "./types";
 
 /**
  * Scaling Validator
@@ -21,4 +22,23 @@ const ScalingValidator:Validator = {
  */
 export function validateScaling(ScalingElement: SlInput): Valid {
 	return validateInputWithHelptext(ScalingElement, "Global Scaling", ScalingValidator, "Scaling factor for all samples. 1.00 = 1mm (default).");
+}
+
+export function validateSampleLabel(LabelElement:SlInput, SessionSamples:Record<string, SampleProperties>): Valid {
+	if (LabelElement.value == "") {
+		markValid(LabelElement, false)
+		LabelElement.helpText = "Sample label must have a unique label.";
+		return {valid: false, InvalidReason: "Sample label must have a unique label."}
+	}
+
+	if (LabelElement.value in SessionSamples) {
+		// do not allow empty input or duplicate labels
+		markValid(LabelElement, false);
+		LabelElement.helpText = "Sample Label already exists.";
+		return {valid: false, InvalidReason: "Sample label must have a unique label."}
+	}
+
+	markValid(LabelElement, true);
+	LabelElement.helpText = "";
+	return {valid: true}
 }

--- a/webct/blueprints/samples/templates/pane.samples.html.j2
+++ b/webct/blueprints/samples/templates/pane.samples.html.j2
@@ -3,37 +3,26 @@
 <sl-dialog label="Select Sample" id="dialogueSampleSelect">
 	<sl-radio-group>
 		<div class="radioselect">
-			<sl-radio value="select" checked id="radioSampleSelect"><h1>Available Models</h1></sl-radio>
+			<sl-radio value="select" checked id="radioSampleSelect"><h1>Use Existing Model</h1></sl-radio>
 			<sl-select placeholder="Select Model" hoist id="selectSample">
 			</sl-select>
-			<sl-input label="Sample Name" placeholder="Unlabeled Sample" id="inputSampleLabel"></sl-input>
 
 		</div>
 		<sl-divider></sl-divider>
 
 		<div>
-			<sl-radio value="upload" id="radioSampleUpload"><h1>Upload Model</h1></sl-radio>
+			<sl-radio value="upload" id="radioSampleUpload"><h1>Upload A New Model</h1></sl-radio>
 			<input type="file" id="inputSampleFile">
 			<sl-progress-bar value="0" id="barSampleUpload">0</sl-progress-bar>
 		</div>
 	</sl-radio-group>
-	
+	<sl-input label="Sample Name" placeholder="Unlabeled Sample" id="inputSampleLabel"></sl-input>
+
 	<div slot="footer">
 		<sl-divider></sl-divider>
 		<div class="buttons">
 			<sl-button variant="" class="close" id="buttonSampleClose">Close</sl-button>
 			<sl-button variant="success" id="buttonSampleSubmit" disabled>Add Sample</sl-button>
-		</div>
-	</div>
-</sl-dialog>
-
-<sl-dialog label="Upload Complete!" id="dialogueUploadComplete">
-	<p>Sample has been uploaded!<br>You can now add the sample using the model dropdown.</p>
-
-		<div slot="footer">
-			<sl-divider></sl-divider>
-			<div class="buttons">
-			<sl-button variant="" class="close" id="buttonUploadClose">Close</sl-button>
 		</div>
 	</div>
 </sl-dialog>


### PR DESCRIPTION
- Removed Post-upload dialog.
- Errored uploads can be cleared by re-opening the add sample dialog
- Sample label is now required for both uploading and selecting existing samples
- Changed section titles to make more sense
	- "Available Models" -> "Use Existing Model"
	- "Upload Model" -> "Upload a new Model"

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/c1931d8f-c173-4a3b-8caf-c3c675206dd3) |![image](https://github.com/user-attachments/assets/c0288bb2-6b66-4b61-b58c-03af986e045f)|