### PR TITLE
fix: :bug: Photon starvation image now aligns with Transmission graph (#114)

### DIFF
--- a/webct/blueprints/preview/routes.py
+++ b/webct/blueprints/preview/routes.py
@@ -28,7 +28,7 @@ def saveGif(array: np.ndarray) -> None:
 def getHistImage(array:np.ndarray, bins:List[float]) -> str:
 	# create a mask of pixels < bin[5]
 	# 0 - 1 - 2 - 3 - 4 - 5 - 6
-	mask = array < bins[5]
+	mask = array < bins[6]
 
 	# create rgb image
 	array = (array - array.min()) / (array.max() - array.min())

--- a/webct/blueprints/preview/static/js/sim/types.ts
+++ b/webct/blueprints/preview/static/js/sim/types.ts
@@ -48,7 +48,7 @@ export class TransmissionDisplay {
 	}
 
 	public displayTransmission(): void {
-
+		let num_px = this.previewData.projection.height * this.previewData.projection.width
 		let title = "Image Transmission";
 		let label = "Transmission";
 
@@ -87,7 +87,7 @@ export class TransmissionDisplay {
 					},
 					title: {
 						display: true,
-						text: "Image Percentage",
+						text: "% of Total pixels",
 					},
 				}
 			},
@@ -105,7 +105,7 @@ export class TransmissionDisplay {
 						// 	return tooltipItem.dataset.label + ": " + tooltipItem.parsed.y.toFixed(2) + "keV"
 						// },
 						title: (tooltipItems) => {
-							return tooltipItems[0].parsed.y.toFixed(0) + "% Transmission: " + tooltipItems[0].parsed.x.toFixed(2) + "% of pixels.";
+							return tooltipItems[0].parsed.y.toFixed(0) + "% Transmission: " + (tooltipItems[0].parsed.x * num_px).toFixed(0) + "px";
 						},
 					}
 				}


### PR DESCRIPTION
- Highlight anything within the 5-6% bin as red, rather than 4%-5%
- Previously, only transmission areas under 5% were highlighted, causing a discontinuety with the graph and photon starvation image. This should hopefully now be fixed.
	- Additionly, transmission graph axis labels have been changed to be more clear, along wthit the tooltip now displaying the total number of pixels in each bin.